### PR TITLE
feat: worktree isolation hooks + configurable model_policy

### DIFF
--- a/.forge.org.example.yaml
+++ b/.forge.org.example.yaml
@@ -71,6 +71,18 @@ scm:
   type: github                            # github | gitlab | bitbucket
   org: acme
 
+# --- Model policy: YOUR org's model floor for ALL agent work (optional). ---
+# This is the floor for every Workflow/subagent stage — both the named roles below AND
+# any one-off agent() call in a hand-authored Workflow. It is OPTIONAL: omit this whole
+# block and the harness simply asks every ad-hoc agent to set its model explicitly. Set
+# it to encode YOUR floor — e.g. ban a model whose output on reasoning-heavy work gets
+# redone (wasting tokens regardless of unit price; optimize for value-per-token, not
+# cheapest token). The rendered skills surface these to the orchestrator at dispatch time.
+model_policy:
+  banned: [haiku]            # models no stage may use (illustrative; tune to your org)
+  default: sonnet            # the floor for reasoning-heavy stages (matches the agents below)
+  rule: "Always set model explicitly on ad-hoc agent() calls; never leave it implicit."
+
 # --- Agent definitions: the ROLES that Workflow stages instantiate. ---
 # These are NOT one-off agents. execute (and refine, for the gate) dispatch them as
 # stages inside a Workflow — the harness has no ad-hoc agent invocation. The harness

--- a/lib/emit.py
+++ b/lib/emit.py
@@ -41,6 +41,31 @@ def resolve_verbs(cfg):
     return {v: overrides.get(v, v) for v in CANONICAL_VERBS}
 
 
+# model_policy is the ORG's model floor for ALL agent work (named roles AND any ad-hoc
+# agent() in a hand-authored Workflow). It is OPTIONAL and configurable per org — the
+# generator never hardcodes a floor, so when the block is absent we supply sane, NEUTRAL
+# defaults rather than requiring it. Exposed as scalars the same way agent models are,
+# so the rendered skills can surface each org's floor via {{MODEL_POLICY_*}}.
+MODEL_POLICY_DEFAULTS = {
+    "default": "the role's configured model",
+    "banned": [],
+    "rule": "Set model explicitly on ad-hoc agent() calls; never leave it implicit.",
+}
+
+
+def model_policy_scalars(cfg):
+    """Read optional cfg['model_policy'] → MODEL_POLICY_* scalars (all strings)."""
+    mp = cfg.get("model_policy", {}) or {}
+    banned = mp.get("banned", MODEL_POLICY_DEFAULTS["banned"])
+    if isinstance(banned, (list, tuple)):
+        banned = ", ".join(str(b) for b in banned)
+    return {
+        "MODEL_POLICY_DEFAULT": str(mp.get("default", MODEL_POLICY_DEFAULTS["default"])),
+        "MODEL_POLICY_BANNED": str(banned),
+        "MODEL_POLICY_RULE": str(mp.get("rule", MODEL_POLICY_DEFAULTS["rule"])),
+    }
+
+
 def agent_field(cfg, name, field, default=None):
     for p in cfg.get("agents", []):
         if p.get("name") == name:
@@ -90,9 +115,12 @@ def build_bindings(cfg: dict) -> dict:
     verbs = resolve_verbs(cfg)
     verb_scalars = {f"VERB_{canon.upper()}": name for canon, name in verbs.items()}
 
+    mp_scalars = model_policy_scalars(cfg)
+
     return {
         "scalars": {
             **verb_scalars,
+            **mp_scalars,
             "ORG_NAME": org["name"],
             "PLUGIN_NAME": plugin["name"],
             "PLUGIN_VERSION": plugin["version"],

--- a/templates/org-plugin/hooks/hooks.json.template
+++ b/templates/org-plugin/hooks/hooks.json.template
@@ -1,6 +1,28 @@
 {
-  "description": "{{ORG_NAME}} harness advisory hooks — prime reminder, handoff nudge, wiki reminder. All non-blocking, fail-open.",
+  "description": "{{ORG_NAME}} harness hooks — advisory reminders (prime/handoff/wiki, non-blocking, fail-open) + worktree isolation for the multi-repo workspace root (WorktreeCreate/Remove).",
   "hooks": {
+    "WorktreeCreate": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/worktree-create.sh\""
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/worktree-remove.sh\""
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "",

--- a/templates/org-plugin/hooks/scripts/worktree-create.sh.template
+++ b/templates/org-plugin/hooks/scripts/worktree-create.sh.template
@@ -1,0 +1,124 @@
+#!/bin/sh
+# worktree-create.sh — WorktreeCreate hook for the {{ORG_NAME}} harness.
+#
+# WHY: Agent/Workflow `isolation: 'worktree'` runs `git worktree add` from the
+#   session cwd. In a multi-repo *workspace root* (whose SUBDIRECTORIES are the real
+#   git repos, the root itself NOT a git repo) the cwd is not a repo, so the built-in
+#   worktree path fails. This hook makes isolation work from that root by resolving
+#   WHICH sibling repo to anchor the worktree in, then creating it there.
+#
+# CONTRACT (code.claude.com/docs/en/hooks.md — WorktreeCreate):
+#   stdin JSON: { cwd, base_branch, worktree_name, worktree_path, session_id, ... }
+#   The hook is NOT told the target repo, so it must resolve it (see below).
+#   On success: print the created worktree path to stdout, exit 0.
+#   On failure: write the reason to stderr, exit non-zero (aborts creation).
+#
+# REPO RESOLUTION (first match wins):
+#   1. cwd is itself a git repo            -> use cwd (the normal single-repo case).
+#   2. worktree_name encodes the repo as  `<repo>/<rest>` or `<repo>--<rest>` and
+#      <repo> is a git subdir of cwd       -> use cwd/<repo>.  (naming convention)
+#   3. $WORKTREE_REPO is set               -> use cwd/$WORKTREE_REPO.
+#   4. cwd has exactly ONE git subdir       -> use it (unambiguous).
+#   5. otherwise                            -> fail with a clear, actionable message.
+#
+# Worktrees are created as siblings under cwd/.worktrees/<name> to keep them out of
+# every repo tree. Fails CLOSED (non-zero) only when it genuinely cannot resolve —
+# never silently picks the wrong repo.
+set -u
+
+INPUT="$(cat 2>/dev/null || true)"
+
+# --- parse stdin (jq required for WorktreeCreate; degrade with a clear error) ---
+if ! command -v jq >/dev/null 2>&1; then
+  echo "worktree-create: jq not found; cannot parse hook input" >&2
+  exit 1
+fi
+CWD="$(printf '%s' "$INPUT"        | jq -r '.cwd // empty')"
+BASE_BRANCH="$(printf '%s' "$INPUT" | jq -r '.base_branch // empty')"
+WT_NAME="$(printf '%s' "$INPUT"     | jq -r '.worktree_name // empty')"
+WT_PATH="$(printf '%s' "$INPUT"     | jq -r '.worktree_path // empty')"
+
+[ -n "$CWD" ] || { echo "worktree-create: no cwd in hook input" >&2; exit 1; }
+[ -n "$WT_NAME" ] || WT_NAME="agent-worktree"
+
+# --- resolve the target repo ---
+TARGET=""
+
+# (1) cwd is a git repo already → standard behavior, anchor there.
+if git -C "$CWD" rev-parse --git-dir >/dev/null 2>&1; then
+  TARGET="$CWD"
+fi
+
+# (2) repo encoded in the worktree name: "<repo>/<rest>" or "<repo>--<rest>".
+if [ -z "$TARGET" ]; then
+  case "$WT_NAME" in
+    */*)  CAND="${WT_NAME%%/*}" ;;
+    *--*) CAND="${WT_NAME%%--*}" ;;
+    *)    CAND="" ;;
+  esac
+  if [ -n "$CAND" ] && git -C "$CWD/$CAND" rev-parse --git-dir >/dev/null 2>&1; then
+    TARGET="$CWD/$CAND"
+  fi
+fi
+
+# (3) explicit env override.
+if [ -z "$TARGET" ] && [ -n "${WORKTREE_REPO:-}" ]; then
+  if git -C "$CWD/$WORKTREE_REPO" rev-parse --git-dir >/dev/null 2>&1; then
+    TARGET="$CWD/$WORKTREE_REPO"
+  fi
+fi
+
+# (4) exactly one git subdir under cwd → unambiguous.
+if [ -z "$TARGET" ]; then
+  COUNT=0
+  ONLY=""
+  for d in "$CWD"/*/; do
+    [ -d "$d" ] || continue
+    if git -C "$d" rev-parse --git-dir >/dev/null 2>&1; then
+      COUNT=$((COUNT + 1)); ONLY="${d%/}"
+    fi
+  done
+  if [ "$COUNT" = "1" ]; then TARGET="$ONLY"; fi
+fi
+
+# (5) give up with an actionable message.
+if [ -z "$TARGET" ]; then
+  echo "worktree-create: cannot resolve target repo from cwd='$CWD' worktree_name='$WT_NAME'." >&2
+  echo "  Encode the repo in the worktree/agent name as '<repo>/<branch>' or '<repo>--<branch>'," >&2
+  echo "  or set WORKTREE_REPO=<repo-subdir>. cwd is not itself a git repo." >&2
+  exit 1
+fi
+
+# --- derive a clean branch name + a worktrees home outside any repo tree ---
+# Prefer the harness-provided worktree_path; else place under cwd/.worktrees/<safe-name>.
+SAFE_NAME="$(printf '%s' "$WT_NAME" | tr '/ :' '---')"
+if [ -z "$WT_PATH" ]; then
+  WT_PATH="$CWD/.worktrees/$SAFE_NAME"
+fi
+mkdir -p "$(dirname "$WT_PATH")" 2>/dev/null || true
+
+# Base the worktree on base_branch if given, else the repo's current HEAD.
+BR_ARGS=""
+if [ -n "$BASE_BRANCH" ]; then BR_ARGS="$BASE_BRANCH"; fi
+
+# Create the worktree on a NEW branch named for the worktree (unique per agent).
+# If the branch already exists, attach to it; if the path exists, reuse it.
+if [ -d "$WT_PATH" ]; then
+  printf '%s\n' "$WT_PATH"; exit 0
+fi
+
+if git -C "$TARGET" show-ref --verify --quiet "refs/heads/$SAFE_NAME"; then
+  # branch exists → check it out into the new worktree
+  if git -C "$TARGET" worktree add "$WT_PATH" "$SAFE_NAME" >/dev/null 2>&1; then
+    printf '%s\n' "$WT_PATH"; exit 0
+  fi
+else
+  # new branch off base (or HEAD)
+  # shellcheck disable=SC2086
+  if git -C "$TARGET" worktree add -b "$SAFE_NAME" "$WT_PATH" $BR_ARGS >/dev/null 2>&1; then
+    printf '%s\n' "$WT_PATH"; exit 0
+  fi
+fi
+
+echo "worktree-create: 'git worktree add' failed in '$TARGET' for '$WT_PATH' (branch '$SAFE_NAME', base '${BASE_BRANCH:-HEAD}')" >&2
+exit 1

--- a/templates/org-plugin/hooks/scripts/worktree-remove.sh.template
+++ b/templates/org-plugin/hooks/scripts/worktree-remove.sh.template
@@ -1,0 +1,45 @@
+#!/bin/sh
+# worktree-remove.sh — WorktreeRemove hook for the {{ORG_NAME}} harness. Pairs with
+# worktree-create.sh: tears down the worktree the create hook made.
+#
+# CONTRACT (code.claude.com/docs/en/hooks.md — WorktreeRemove):
+#   stdin JSON: { cwd, worktree_path, worktree_name, session_id, ... }
+#   Cannot block; exit code is advisory/logged only. Best-effort cleanup.
+#
+# Because the create hook may anchor the worktree in ANY sibling repo, we find the
+# owning repo by scanning `git worktree list` across cwd's git subdirs, then remove
+# it there. Always exits 0 (never breaks a session on cleanup).
+set -u
+trap 'exit 0' EXIT
+
+INPUT="$(cat 2>/dev/null || true)"
+command -v jq >/dev/null 2>&1 || exit 0
+
+CWD="$(printf '%s' "$INPUT"     | jq -r '.cwd // empty')"
+WT_PATH="$(printf '%s' "$INPUT" | jq -r '.worktree_path // empty')"
+[ -n "$WT_PATH" ] || exit 0
+[ -n "$CWD" ] || CWD="$(dirname "$WT_PATH")"
+
+# If cwd itself owns it, remove there first (single-repo case).
+if git -C "$CWD" rev-parse --git-dir >/dev/null 2>&1; then
+  if git -C "$CWD" worktree list 2>/dev/null | grep -Fq "$WT_PATH"; then
+    git -C "$CWD" worktree remove --force "$WT_PATH" >/dev/null 2>&1 || true
+    git -C "$CWD" worktree prune >/dev/null 2>&1 || true
+    exit 0
+  fi
+fi
+
+# Otherwise scan sibling git repos for the one that registered this worktree.
+for d in "$CWD"/*/; do
+  [ -d "$d" ] || continue
+  git -C "$d" rev-parse --git-dir >/dev/null 2>&1 || continue
+  if git -C "$d" worktree list 2>/dev/null | grep -Fq "$WT_PATH"; then
+    git -C "$d" worktree remove --force "$WT_PATH" >/dev/null 2>&1 || true
+    git -C "$d" worktree prune >/dev/null 2>&1 || true
+    break
+  fi
+done
+
+# Last resort: drop the directory if nothing claimed it.
+[ -d "$WT_PATH" ] && rm -rf "$WT_PATH" 2>/dev/null || true
+exit 0

--- a/templates/org-plugin/skills/execute/SKILL.md.template
+++ b/templates/org-plugin/skills/execute/SKILL.md.template
@@ -106,6 +106,27 @@ the org runs may differ — but if it isn't the Workflow tool, it MUST still pre
 implement/review context split. A single agent that implements then reviews its own
 diff in one context is the forbidden anti-pattern.
 
+**Worktree isolation in a multi-repo workspace.** When a session runs from a
+*workspace root* (whose subdirectories are the real git repos, the root itself not a
+repo), `isolation: 'worktree'` can only create a worktree if it knows which repo to
+anchor it in. The harness's `WorktreeCreate` hook (`hooks/scripts/worktree-create.sh`)
+resolves the target repo from the **agent label / worktree name**, so name isolated
+implementer stages `<repo>/<branch>` (or `<repo>--<branch>`), e.g.
+`label: '<repo>/<ticket>'`. Resolution order: cwd-is-a-repo → repo encoded in the name
+→ the `WORKTREE_REPO` env var → the sole git subdir if there's exactly one → else it
+**fails closed** (it will never guess the wrong repo). Single-implementer stages don't
+need a worktree at all — a dedicated branch in the target repo is enough isolation;
+reserve worktrees for parallel implementers that would otherwise share one working tree.
+
+**Always dispatch via the standard agentTypes (`implementer`/`reviewer`/`{{VERB_GATE}}`),
+never bare ad-hoc agents.** Those archetypes pin `model` + `effort` in their frontmatter
+(see `agents/`), so every stage runs at the right depth automatically. A workflow stage
+written with no `agentType` and no explicit `model` inherits/defaults and can silently
+land on a banned model. **Model floor for this org:** default **{{MODEL_POLICY_DEFAULT}}**;
+banned: **{{MODEL_POLICY_BANNED}}**. {{MODEL_POLICY_RULE}} If a stage genuinely needs a
+one-off (non-archetype) agent, it MUST set `model` explicitly — never leave it implicit.
+We optimize for value-per-token, not cheapest token.
+
 ### 6. Monitor + surface decisions
 
 Track agents at T1 (name, repo, status, last activity); promote one to T2 only when the

--- a/tests/test_model_policy_binding.py
+++ b/tests/test_model_policy_binding.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Tests for the model_policy config binding in emit.build_bindings.
+
+Run:  uv run --with pyyaml python tests/test_model_policy_binding.py
+
+model_policy is an OPTIONAL, org-configurable block (the org's model floor).
+emit must:
+  - expose MODEL_POLICY_DEFAULT / MODEL_POLICY_BANNED / MODEL_POLICY_RULE scalars,
+  - read them from cfg["model_policy"] when present,
+  - supply sane NEUTRAL defaults when the block is absent (never required).
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+import emit  # noqa: E402
+
+BASE = {
+    "org": {"name": "Testco", "slug": "testco"},
+    "plugin": {
+        "name": "testco-harness", "version": "0.1.0", "description": "d",
+        "author": {"name": "Testco Platform Engineering", "url": "https://github.com/testco"},
+        "homepage": "https://github.com/testco/testco-harness", "license": "UNLICENSED",
+    },
+    "org_wiki": {
+        "name": "testco-wiki", "remote": "git@github.com:testco/testco-wiki.git",
+        "local_path_env": "TESTCO_WIKI", "default_local_path": "~/work/testco-wiki",
+        "prime_reads": ["operating-model.md"],
+    },
+    "tracker": {"type": "jira", "config": {}},
+    "agents": [
+        {"name": "implementer", "model": "sonnet"},
+        {"name": "reviewer", "model": "sonnet"},
+        {"name": "gate", "model": "sonnet"},
+    ],
+}
+
+
+def cfg_with(**over):
+    import copy
+    c = copy.deepcopy(BASE)
+    c.update(over)
+    return c
+
+
+def test_present_block_is_read():
+    c = cfg_with(model_policy={
+        "banned": ["haiku"], "default": "opus",
+        "rule": "Never Haiku. Always set model explicitly.",
+    })
+    s = emit.build_bindings(c)["scalars"]
+    assert s["MODEL_POLICY_DEFAULT"] == "opus", s["MODEL_POLICY_DEFAULT"]
+    assert s["MODEL_POLICY_BANNED"] == "haiku", s["MODEL_POLICY_BANNED"]
+    assert s["MODEL_POLICY_RULE"] == "Never Haiku. Always set model explicitly.", s["MODEL_POLICY_RULE"]
+
+
+def test_banned_list_renders_comma_joined():
+    c = cfg_with(model_policy={"banned": ["haiku", "foo"], "default": "opus", "rule": "r"})
+    s = emit.build_bindings(c)["scalars"]
+    assert s["MODEL_POLICY_BANNED"] == "haiku, foo", s["MODEL_POLICY_BANNED"]
+
+
+def test_absent_block_supplies_defaults():
+    c = cfg_with()  # no model_policy
+    s = emit.build_bindings(c)["scalars"]
+    # defaults must exist (block is optional) and be neutral non-empty strings
+    assert s["MODEL_POLICY_DEFAULT"], "MODEL_POLICY_DEFAULT default missing"
+    assert s["MODEL_POLICY_BANNED"] != "" or s["MODEL_POLICY_BANNED"] == "", "key must exist"
+    assert "MODEL_POLICY_BANNED" in s
+    assert s["MODEL_POLICY_RULE"], "MODEL_POLICY_RULE default missing"
+
+
+def test_scalars_are_strings():
+    c = cfg_with(model_policy={"banned": ["haiku"], "default": "opus", "rule": "r"})
+    s = emit.build_bindings(c)["scalars"]
+    for k in ("MODEL_POLICY_DEFAULT", "MODEL_POLICY_BANNED", "MODEL_POLICY_RULE"):
+        assert isinstance(s[k], str), f"{k} must be str, got {type(s[k])}"
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {fn.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR {fn.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
Ports two generator features onto v0.3.0 (re-applied via cherry-pick; the original branch was cut from the pre-v0.3.0 dev lineage and had no shared history with the squashed public main).

**A. Worktree isolation (template).** New `hooks/scripts/worktree-{create,remove}.sh.template` + WorktreeCreate/WorktreeRemove wiring in `hooks.json.template`. Makes `isolation: 'worktree'` work when a session runs from a multi-repo workspace root (root not a git repo; subdirs are): resolves the target repo from the agent/worktree name `<repo>/<branch>`, with fallbacks (cwd-is-repo, neutral `WORKTREE_REPO` env, sole subdir) and a fail-closed guard. Execute skill documents the convention.

**B. Configurable model_policy (binding).** `lib/emit.py` reads an optional `model_policy` block → `MODEL_POLICY_*` scalars (neutral defaults when absent; never required). Example block added to `.forge.org.example.yaml`; surfaced in the execute skill via placeholders so each org sets its own model floor.

**Validation:** emit OK + leak gate clean (neutral env var `WORKTREE_REPO`, `{{ORG_NAME}}`, zero generator/org identity in output); `claude plugin validate --strict` passed; 4/4 binding tests; emitted hooks.json valid, both worktree events wired. Reviewed by a separate agent (APPROVE, neutrality clean).