### PR TITLE
feat(tracker): add jira-acli adapter (Atlassian acli CLI)

### DIFF
--- a/.forge.org.example.yaml
+++ b/.forge.org.example.yaml
@@ -58,13 +58,22 @@ org_wiki:
     - decisions/             # ADRs — read those relevant to the work
 
 # --- Tracker: the coordination bus. Adapter-shaped (see forge/adapters/tracker/). ---
+# `type` selects the tracker adapter. Valid Jira options today:
+#   jira-mcp   — Jira Cloud over the Atlassian MCP server (needs cloud_id).
+#   jira-acli  — Jira Cloud over Atlassian's official `acli` CLI (no MCP, no cloud_id;
+#                acli holds its own auth context — run `acli jira auth login --web`).
+# The two share project_key + base_url; only jira-mcp also takes a cloud_id.
 tracker:
-  type: jira                              # jira | github | gitlab | linear | asana
-  via: atlassian-mcp                      # mcp | cli
+  type: jira-mcp                          # jira-mcp | jira-acli | github | gitlab | linear | asana
   config:
-    cloud_id: "00000000-0000-0000-0000-000000000000"
+    cloud_id: "00000000-0000-0000-0000-000000000000"   # jira-mcp only; omit for jira-acli
     project_key: ACME
     base_url: https://acme.atlassian.net
+  # jira-acli alternative (no cloud_id — acli resolves the site from its auth context):
+  #   type: jira-acli
+  #   config:
+  #     project_key: ACME
+  #     base_url: https://acme.atlassian.net
 
 # --- SCM: where code + PRs live. ---
 scm:

--- a/adapters/tracker/jira-acli.md
+++ b/adapters/tracker/jira-acli.md
@@ -1,0 +1,152 @@
+---
+type: jira-acli
+name: jira-acli
+description: Jira Cloud driven through Atlassian's official `acli` CLI (no MCP). Streams as labels within one project; auth lives in acli's own context.
+required_clis:
+  - name: acli
+    test: "acli jira auth status"
+    install_hint:
+      macos: "brew tap atlassian/homebrew-acli && brew install acli"
+      linux: "https://developer.atlassian.com/cloud/acli/guides/install-acli/"
+optional_mcp_servers: []
+config_schema:
+  project_key: { type: string, required: true, example: "TEAM" }
+  base_url: { type: string, required: true, example: "https://your-team.atlassian.net" }
+---
+
+# Adapter: jira-acli
+
+Jira via Atlassian's official **`acli`** CLI (`acli jira workitem …`), not the MCP and
+not the third-party `jira` CLI. Use this when the org drives Jira through `acli` and
+prefers a CLI auth context over an MCP connection. `acli` authenticates itself (`acli
+jira auth login`); there is **no `cloud_id`** to configure here — `acli` resolves the
+site from its own auth context. Coordination and traceability flow through Jira; this
+adapter supplies the snippets the org-plugin skills inline.
+
+## Skill snippets
+
+These map to the `{{TRACKER_*_SNIPPET}}` placeholders in `templates/org-plugin/`.
+`project_key` is substituted from `.forge.org.yaml`. Verbs validated against `acli`
+v1.3.19.
+
+### `TRACKER_PRIME_SNIPPET`
+
+```bash
+# My in-flight work (CSV so the agent can read it back without ADF noise):
+acli jira workitem search \
+  --jql "project = {{tracker.config.project_key}} AND assignee = currentUser() AND statusCategory != Done ORDER BY updated DESC" \
+  --fields key,status,summary --csv
+
+# A specific ticket (if a key was passed):
+acli jira workitem view <key> --fields summary,status,labels
+```
+
+Surface results at T1 (key, summary, status); pull full bodies only when a step needs them.
+
+### `TRACKER_VIEW_ISSUE_SNIPPET`
+
+```bash
+# Load the ticket. Read summary + status first; promote to the full body only when a
+# decision requires it. Add --json when you need to parse fields programmatically.
+acli jira workitem view <key> --fields summary,status,labels
+acli jira workitem view <key> --fields summary,status,labels --json
+```
+
+### `TRACKER_COMMENT_SNIPPET`
+
+```bash
+# Persist an update to the ticket as a comment. NOTE: the verb is `comment create`
+# (NOT `comment add`). Body inline with --body, or from a file with --body-file:
+acli jira workitem comment create --key <key> --body "<update>"
+acli jira workitem comment create --key <key> --body-file ./update.md
+```
+
+### `TRACKER_CREATE_TASK_SNIPPET`
+
+```bash
+# Create a child task under a story. DISCOVER the child type at runtime — boards differ
+# per org, so do NOT assume an issue-type name. First inspect a sibling to learn what
+# type children use under a story:
+acli jira workitem view <a-sibling-child-of-the-story> --fields issuetype --json
+#   → read the issuetype name from the JSON and use it verbatim as <child-type>.
+
+acli jira workitem create \
+  --project {{tracker.config.project_key}} \
+  --type "<child-type>" \
+  --parent <story-key> \
+  --summary "<repo>: <concern>" \
+  --description "<acceptance criteria + test expectations + constraints + deps>"
+
+# If the board has no sibling to inspect, attempt the create and, on a type error,
+# retry with a corrected --type from the error's hint. Discover, do not assume.
+```
+
+### `TRACKER_BACKLOG_SNIPPET`
+
+```bash
+# Find swarm-ready work: the refine→execute gate is carried by the board-agnostic
+# `agent-ready` LABEL (see TRACKER_GATE_SNIPPET), not a board-specific status.
+acli jira workitem search \
+  --jql "project = {{tracker.config.project_key}} AND labels = agent-ready AND statusCategory != Done" \
+  --fields key,status,summary --csv
+```
+
+When ORIGINATING a backlog tree (epics + their stories), do NOT assume issue-type names
+exist by `Epic`/`Story` — DISCOVER the board's hierarchy first (inspect an existing
+top-level item and a story under it with `acli jira workitem view <key> --fields
+issuetype --json`), then `acli jira workitem create` the top-breakdown type, and create
+stories under it with `--parent <epic-key>`. Stories are created in OUTLINE form (need +
+repos + acceptance-test sketch) and become agent-ready later via refine — do NOT label
+them agent-ready at creation. The human owns the backlog.
+
+### `TRACKER_GATE_SNIPPET`
+
+```bash
+# The refine→execute gate is a board-agnostic LABEL, not a board-specific status. Every
+# Jira project supports labels with no admin setup, so this works on any team's board
+# while leaving their own workflow states untouched.
+#
+# The harness owns a small label namespace:
+#   agent-ready    — refine's gate passed (problem refined + acceptance/validation test defined). REQUIRED before execute.
+#   agent-blocked  — an agent surfaced a decision that needs the engineer.
+
+# Read the gate (does this ticket carry the label?):
+acli jira workitem view <key> --fields summary,status,labels
+
+# Apply the gate label (acli merges into existing labels):
+acli jira workitem edit --key <key> --labels "agent-ready"
+# Clear it:
+acli jira workitem edit --key <key> --remove-labels "agent-ready"
+```
+
+```bash
+# A team MAY also mirror the gate to one of their real statuses. If the wiki's operating
+# model names that mapping (e.g. "agent-ready ⇒ status 'Ready for Dev'"), honor it.
+# acli takes the TARGET status name directly — no separate get-transitions step:
+acli jira workitem transition --key <key> --status "<TargetStatus>"
+```
+
+The LABEL is canonical and board-agnostic; the status mirror is optional polish.
+
+## Doctor
+
+### `TRACKER_DOCTOR_SNIPPET`
+
+```bash
+# 1. acli installed?
+command -v acli >/dev/null \
+  || echo "install: brew tap atlassian/homebrew-acli && brew install acli"
+
+# 2. authenticated? (exit 0 = authed)
+acli jira auth status \
+  || acli jira auth login --web
+```
+
+## Notes
+
+- `acli` authenticates per-machine via `acli jira auth login --web`; there is no
+  `cloud_id` in this adapter's config — `acli` resolves the site from its auth context.
+- The verb for comments is `comment create` (not `comment add`); `edit` takes
+  `--labels` / `--remove-labels`; `transition` takes the target `--status` name directly.
+- Add `--json` on `view` when you need to parse fields (e.g. issuetype discovery);
+  prefer `--csv` on `search` for compact, parseable list output.

--- a/templates/org-plugin/skills/setup/SKILL.md.template
+++ b/templates/org-plugin/skills/setup/SKILL.md.template
@@ -1,6 +1,6 @@
 ---
 name: {{VERB_SETUP}}
-description: One-time bootstrap for {{PLUGIN_NAME}} — clone the {{ORG_NAME}} org brain into your working directory, point the harness at it, and verify the tracker MCP. Run once in a fresh directory, before prime.
+description: One-time bootstrap for {{PLUGIN_NAME}} — clone the {{ORG_NAME}} org brain into your working directory, point the harness at it, and verify the tracker. Run once in a fresh directory, before prime.
 ---
 
 # /{{VERB_SETUP}} — One-time bootstrap ({{ORG_NAME}})
@@ -81,17 +81,18 @@ EOF
 Then edit the `## Repos` list to name the actual repos. `{{VERB_PRIME}}` reads this; `{{VERB_EXECUTE}}`
 scopes each task to one of these repos.
 
-### 4. Verify the tracker MCP is connected
+### 4. Verify the tracker is reachable
 
-{{PLUGIN_NAME}} drives the tracker through its MCP. Confirm the tools resolve; if not,
-reconnect:
+{{PLUGIN_NAME}} drives the tracker through whatever interface this org configured (a CLI
+or an MCP server — the tracker adapter decides). Run the adapter's own check to confirm
+it resolves, and follow its remediation if it doesn't:
 
 {{TRACKER_DOCTOR_SNIPPET}}
 
 ### 5. Confirm + hand off to prime
 
 State, in a couple of lines: `{{ORG_WIKI_NAME}}` cloned here (✓), `{{ORG_WIKI_PATH_ENV}}`
-set to it (✓), repo index present if multi-repo (✓), tracker MCP reachable (✓). Then:
+set to it (✓), repo index present if multi-repo (✓), tracker reachable (✓). Then:
 
 ```
 Setup complete. From here on, just run /{{PLUGIN_NAME}}:{{VERB_PRIME}} at the start of each
@@ -102,13 +103,13 @@ workspace, and calibrates you.
 ## When to re-run
 
 - Fresh machine or new working directory with no wiki → run `{{VERB_SETUP}}`.
-- Wiki moved, or MCP stopped resolving → re-run; the steps are idempotent.
+- Wiki moved, or the tracker stopped resolving → re-run; the steps are idempotent.
 
 Otherwise you won't touch this — it's the one-time door, and `{{VERB_PRIME}}` is the daily one.
 
 ## Tool contract
 
-`{{VERB_SETUP}}` clones the wiki (a one-time write to your local filesystem) and checks the MCP.
+`{{VERB_SETUP}}` clones the wiki (a one-time write to your local filesystem) and checks the tracker.
 It does **not** write to the wiki, the tracker, or any repo. After it runs, `{{VERB_PRIME}}` owns
 every session.
 


### PR DESCRIPTION
## What

Adds a new **CLI-based Jira tracker adapter** (`adapters/tracker/jira-acli.md`) driven by Atlassian's official **`acli`** — a no-MCP alternative to the existing `jira-mcp` adapter.

## Why

Some orgs prefer driving Jira through a CLI auth context rather than an MCP connection. `acli` authenticates per-machine (`acli jira auth login --web`) and resolves the site itself, so this adapter needs **no `cloud_id`** — only `project_key` + `base_url`.

## Changes

- **NEW** `adapters/tracker/jira-acli.md` — frontmatter (`type: jira-acli`, `required_clis: [acli]` with macOS/Linux install hints, `optional_mcp_servers: []`, `config_schema` of `project_key` + `base_url`) and all **7** `TRACKER_*_SNIPPET` blocks rewritten to `acli` verbs (validated against `acli` v1.3.19):
  - `workitem search --jql … --csv`, `workitem view`, `workitem comment create` (not `comment add`), `workitem create`, `workitem edit --labels/--remove-labels`, `workitem transition --status`, `auth status` / `auth login --web`.
  - Child issue-type is **discovered at runtime** (inspect a sibling's `issuetype --json`, or retry on a type error) — **no issue-type names baked in**, so it stays board/org-agnostic.
- **EDIT** `templates/org-plugin/skills/setup/SKILL.md.template` — neutralize "tracker MCP" prose to interface-agnostic wording; it simply renders `{{TRACKER_DOCTOR_SNIPPET}}` for verification (works for CLI or MCP adapters).
- **EDIT** `.forge.org.example.yaml` — document `type: jira-acli` as a valid org-agnostic tracker option alongside `jira-mcp` (example values only).

## Sanity

- All 7 snippet labels present in the adapter (so `lib/emit.py` won't abort).
- No tenant-specific identifiers, no `cloud_id`, no hardcoded issue-type names. Org-neutral, OSS-safe.
- `emit` intentionally not run here (that's a downstream stage).