### PR TITLE
feat(execute): orchestrator context-economy discipline in engage skill

### DIFF
--- a/templates/org-plugin/skills/execute/SKILL.md.template
+++ b/templates/org-plugin/skills/execute/SKILL.md.template
@@ -127,6 +127,18 @@ banned: **{{MODEL_POLICY_BANNED}}**. {{MODEL_POLICY_RULE}} If a stage genuinely 
 one-off (non-archetype) agent, it MUST set `model` explicitly — never leave it implicit.
 We optimize for value-per-token, not cheapest token.
 
+**Context economy — keep the orchestrator lean.** You are the one long-lived context;
+every token a stage pours into it is permanent. So make each stage **return only
+structured result lines** — e.g. a PR url plus a single `PASS`/`FAIL` verdict (the
+reviewer's), maybe a one-line reason — and consume *only those lines*. Never pull a
+subagent's full transcript, its reasoning, or the diff into your own context; that is
+the subagent's to hold, not yours. Hold conclusions, not contents: when a stage returns
+`FAIL`, dispatch the fix **by reference** (task key + PR url + the verdict line), letting
+a fresh subagent re-read the diff in *its* context rather than rehydrating it in yours.
+This is progressive disclosure (ADR-0003) applied to the orchestrator itself — load the
+verdict at T1, never the body — and it is what lets the single orchestrator run a long
+wave before it needs `/handoff`.
+
 ### 6. Monitor + surface decisions
 
 Track agents at T1 (name, repo, status, last activity); promote one to T2 only when the


### PR DESCRIPTION
## What

Adds a concise, org-neutral subsection to the engage (`execute`) skill template's dispatch flow that instructs the **orchestrator** to:

- have each Workflow stage **RETURN only structured result lines** (a PR url + a `PASS`/`FAIL` verdict) and consume **only** those lines — never pulling a subagent's full transcript or the diff into the orchestrator's own context;
- **hold conclusions, not contents** — dispatch fixes **by reference** (task key + PR url + verdict line), letting a fresh subagent re-read the diff in *its* context;
- keep the single long-lived orchestrator lean so a wave runs long before needing `/handoff`.

## Why

Frames the discipline as the operational expression of **progressive disclosure (ADR-0003)** — applied to the orchestrator itself (load the verdict at T1, never the body). Bakes the context-economy practice into the emitted skill so every instance enforces it, rather than leaving it as wiki-only documentation.

Tracker/tool-agnostic, org-neutral; matches the surrounding template voice. +12 lines, one file.