### PR TITLE
fix(tracker/jira-acli): comment-read snippet + wire into read-path skills

### DIFF
--- a/adapters/tracker/jira-acli.md
+++ b/adapters/tracker/jira-acli.md
@@ -52,6 +52,14 @@ acli jira workitem view <key> --fields summary,status,labels
 acli jira workitem view <key> --fields summary,status,labels --json
 ```
 
+### `TRACKER_COMMENT_LIST_SNIPPET`
+
+```bash
+# Read the ticket's COMMENTS. `view` and `--json` do NOT include comments — they
+# must be fetched separately. Decisions, refinements, and PR/VERDICT lines live here.
+acli jira workitem comment list --key <key>
+```
+
 ### `TRACKER_COMMENT_SNIPPET`
 
 ```bash
@@ -148,5 +156,8 @@ acli jira auth status \
   `cloud_id` in this adapter's config — `acli` resolves the site from its auth context.
 - The verb for comments is `comment create` (not `comment add`); `edit` takes
   `--labels` / `--remove-labels`; `transition` takes the target `--status` name directly.
+- `view` (and `view --json`) exclude comments — they return only the configured
+  `--fields`. The read verb for comments is `comment list --key <key>`; use it whenever
+  you need a ticket's full state (prior decisions/refinements/PR/VERDICT lines).
 - Add `--json` on `view` when you need to parse fields (e.g. issuetype discovery);
   prefer `--csv` on `search` for compact, parseable list output.

--- a/lib/emit.py
+++ b/lib/emit.py
@@ -145,9 +145,9 @@ def build_bindings(cfg: dict) -> dict:
         "snippets": [
             {"placeholder": p, "adapter": adapter, "label": p, "vars": snippet_vars}
             for p in ("TRACKER_PRIME_SNIPPET", "TRACKER_VIEW_ISSUE_SNIPPET",
-                      "TRACKER_COMMENT_SNIPPET", "TRACKER_CREATE_TASK_SNIPPET",
-                      "TRACKER_BACKLOG_SNIPPET", "TRACKER_GATE_SNIPPET",
-                      "TRACKER_DOCTOR_SNIPPET")
+                      "TRACKER_COMMENT_LIST_SNIPPET", "TRACKER_COMMENT_SNIPPET",
+                      "TRACKER_CREATE_TASK_SNIPPET", "TRACKER_BACKLOG_SNIPPET",
+                      "TRACKER_GATE_SNIPPET", "TRACKER_DOCTOR_SNIPPET")
         ],
     }
 

--- a/templates/org-plugin/skills/execute/SKILL.md.template
+++ b/templates/org-plugin/skills/execute/SKILL.md.template
@@ -42,6 +42,12 @@ isolation. You (with the engineer) stay top-of-loop; the agents are scoped hands
 
 {{TRACKER_VIEW_ISSUE_SNIPPET}}
 
+Also read the ticket's comments — the refinement and any batched decisions are recorded
+there, not in the description, and the view above does not include them. Miss these and
+you decompose against a stale spec:
+
+{{TRACKER_COMMENT_LIST_SNIPPET}}
+
 Promote to the full refined spec (SLOs, acceptance/validation test, design controls,
 dependencies) only when proposing the decomposition.
 

--- a/templates/org-plugin/skills/prime/SKILL.md.template
+++ b/templates/org-plugin/skills/prime/SKILL.md.template
@@ -73,6 +73,11 @@ ls "$WIKI/decisions/"
 
 {{TRACKER_PRIME_SNIPPET}}
 
+When a ticket key was passed, also read its comments — prior decisions/refinements
+land there, not in the description, and the view above does not include them:
+
+{{TRACKER_COMMENT_LIST_SNIPPET}}
+
 ### 7. Load the project's repo index (the workspace top-level `CLAUDE.md`)
 
 If you started at a multi-repo workspace top level, read its `CLAUDE.md` — that is the

--- a/templates/org-plugin/skills/refine/SKILL.md.template
+++ b/templates/org-plugin/skills/refine/SKILL.md.template
@@ -34,6 +34,11 @@ at T1 first; promote to detail only when a specific decision needs it.
 
 {{TRACKER_VIEW_ISSUE_SNIPPET}}
 
+Also read the ticket's comments — prior decisions/refinements are recorded there, not
+in the description, and the view above does not include them:
+
+{{TRACKER_COMMENT_LIST_SNIPPET}}
+
 Surface: key, title, the user need / problem statement, current state. Don't pull
 the full body until a decision requires it.
 


### PR DESCRIPTION
## Defect

The jira-acli adapter's ticket-read snippets fetch only summary/status/labels via `acli jira workitem view`, which does **not** return comments. Comments — where decisions, refinements, and PR/VERDICT lines are recorded — are only retrievable via the separate verb `acli jira workitem comment list --key <key>`. Every skill read-path was therefore comment-blind (this is the exact gap that caused a dispatched execute agent to miss ticket-comment decisions).

## Fix (PR1 of 2)

- **adapters/tracker/jira-acli.md** — new `### \`TRACKER_COMMENT_LIST_SNIPPET\`` section (`acli jira workitem comment list --key <key>`), plus a "## Notes" bullet documenting that `view`/`--json` exclude comments and `comment list` is the read verb.
- **lib/emit.py** — register `TRACKER_COMMENT_LIST_SNIPPET` in `build_bindings`' snippets tuple (only Python change).
- **skills/prime, refine, execute** — thread `{{TRACKER_COMMENT_LIST_SNIPPET}}` into the three read-heavy skill templates, each preceded by a one-line note that prior decisions/refinements live in comments, not the description. Gate sites (execute:33, refine:95) left lean — the gate only needs labels.

## Verify

- `emit.build_bindings` (jira-acli cfg) lists the new snippet in its snippets tuple.
- `uv run python lib/render.py --bindings <jira-acli bindings> --templates templates/org-plugin --out … --leak-check` → **OK rendered 19 files**, leak gate clean, **no surviving `{{…}}`**; snippet body resolves in prime/refine/execute.
- `uv run --with pyyaml --with pytest pytest -q` → **4 passed**.

Per ADR-0001: one cohesive behavior change (add read snippet + wire it). No unrelated edits.