### PR TITLE
test(adapters): golden-render harness guarding read-path comment-reads (PR2)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,3 +19,10 @@ jobs:
         run: |
           npm install -g @anthropic-ai/claude-code
           claude plugin validate .
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Adapter render tests
+        # Golden-render harness for tracker adapters (docs/ADAPTERS.md §"Adapter
+        # doctor self-tests"). Catches comment-blind read paths and unresolved
+        # placeholders. See tests/test_adapter_render.py.
+        run: uv run --with pytest --with pyyaml pytest tests/ -q

--- a/adapters/tracker/_test/sample.forge.org.yaml
+++ b/adapters/tracker/_test/sample.forge.org.yaml
@@ -1,0 +1,40 @@
+# FIXTURE — minimal .forge.org.yaml for the adapter golden-render harness.
+# Not a real org config. Provides exactly the keys lib.emit.build_bindings
+# require()s, with non-example values so the identity checks pass. The tracker
+# is wired to the jira-acli adapter so the rendered read-path skills inline its
+# `comment list` snippet (the contract this harness guards — see PR1).
+org:
+  name: Fixtureco
+  slug: fixtureco
+
+plugin:
+  name: fixtureco-harness
+  version: 0.0.0
+  description: Fixture plugin for the adapter render test
+  author:
+    name: Fixtureco Platform Engineering
+    url: https://github.com/fixtureco
+  homepage: https://github.com/fixtureco/fixtureco-harness
+  license: UNLICENSED
+
+org_wiki:
+  name: fixtureco-wiki
+  remote: git@github.com:fixtureco/fixtureco-wiki.git
+  local_path_env: FIXTURECO_WIKI
+  default_local_path: ~/work/fixtureco-wiki
+  prime_reads:
+    - operating-model.md
+
+tracker:
+  type: jira-acli
+  config:
+    project_key: FIX
+    base_url: https://fixtureco.atlassian.net
+
+agents:
+  - name: implementer
+    model: opus
+  - name: reviewer
+    model: opus
+  - name: gate
+    model: opus

--- a/adapters/tracker/jira-acli.md
+++ b/adapters/tracker/jira-acli.md
@@ -52,6 +52,14 @@ acli jira workitem view <key> --fields summary,status,labels
 acli jira workitem view <key> --fields summary,status,labels --json
 ```
 
+### `TRACKER_COMMENT_LIST_SNIPPET`
+
+```bash
+# Read the ticket's COMMENTS. `view` and `--json` do NOT include comments — they
+# must be fetched separately. Decisions, refinements, and PR/VERDICT lines live here.
+acli jira workitem comment list --key <key>
+```
+
 ### `TRACKER_COMMENT_SNIPPET`
 
 ```bash
@@ -148,5 +156,8 @@ acli jira auth status \
   `cloud_id` in this adapter's config — `acli` resolves the site from its auth context.
 - The verb for comments is `comment create` (not `comment add`); `edit` takes
   `--labels` / `--remove-labels`; `transition` takes the target `--status` name directly.
+- `view` (and `view --json`) exclude comments — they return only the configured
+  `--fields`. The read verb for comments is `comment list --key <key>`; use it whenever
+  you need a ticket's full state (prior decisions/refinements/PR/VERDICT lines).
 - Add `--json` on `view` when you need to parse fields (e.g. issuetype discovery);
   prefer `--csv` on `search` for compact, parseable list output.

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -159,8 +159,8 @@ The forge plugin's CI runs these to catch regressions (see
 `tests/test_adapter_render.py`, wired into `.github/workflows/validate.yml`).
 
 > **Mirror on the published side (TODO).** The render harness guards the
-> *generator*. The EMITTED package repo (e.g. `proscia-techops/proscia-hyperdrive`)
-> should carry an equivalent guard in its own CI — a grep/test asserting the
+> *generator*. The EMITTED package repo (the org's generated plugin) should
+> carry an equivalent guard in its own CI — a grep/test asserting the
 > published skills' ticket-read paths include `comment list` (i.e. are not
 > comment-blind). That mirror is a re-emit follow-up, out of scope for forge.
 

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -155,7 +155,14 @@ Each adapter should ship a `_test/` dir with:
 - An expected rendered `prime/SKILL.md`
 - An expected rendered `dispatch/SKILL.md`
 
-The forge plugin's CI runs these to catch regressions.
+The forge plugin's CI runs these to catch regressions (see
+`tests/test_adapter_render.py`, wired into `.github/workflows/validate.yml`).
+
+> **Mirror on the published side (TODO).** The render harness guards the
+> *generator*. The EMITTED package repo (e.g. `proscia-techops/proscia-hyperdrive`)
+> should carry an equivalent guard in its own CI — a grep/test asserting the
+> published skills' ticket-read paths include `comment list` (i.e. are not
+> comment-blind). That mirror is a re-emit follow-up, out of scope for forge.
 
 ## Writing a new adapter
 

--- a/lib/emit.py
+++ b/lib/emit.py
@@ -145,9 +145,9 @@ def build_bindings(cfg: dict) -> dict:
         "snippets": [
             {"placeholder": p, "adapter": adapter, "label": p, "vars": snippet_vars}
             for p in ("TRACKER_PRIME_SNIPPET", "TRACKER_VIEW_ISSUE_SNIPPET",
-                      "TRACKER_COMMENT_SNIPPET", "TRACKER_CREATE_TASK_SNIPPET",
-                      "TRACKER_BACKLOG_SNIPPET", "TRACKER_GATE_SNIPPET",
-                      "TRACKER_DOCTOR_SNIPPET")
+                      "TRACKER_COMMENT_LIST_SNIPPET", "TRACKER_COMMENT_SNIPPET",
+                      "TRACKER_CREATE_TASK_SNIPPET", "TRACKER_BACKLOG_SNIPPET",
+                      "TRACKER_GATE_SNIPPET", "TRACKER_DOCTOR_SNIPPET")
         ],
     }
 

--- a/templates/org-plugin/skills/execute/SKILL.md.template
+++ b/templates/org-plugin/skills/execute/SKILL.md.template
@@ -42,6 +42,12 @@ isolation. You (with the engineer) stay top-of-loop; the agents are scoped hands
 
 {{TRACKER_VIEW_ISSUE_SNIPPET}}
 
+Also read the ticket's comments — the refinement and any batched decisions are recorded
+there, not in the description, and the view above does not include them. Miss these and
+you decompose against a stale spec:
+
+{{TRACKER_COMMENT_LIST_SNIPPET}}
+
 Promote to the full refined spec (SLOs, acceptance/validation test, design controls,
 dependencies) only when proposing the decomposition.
 

--- a/templates/org-plugin/skills/prime/SKILL.md.template
+++ b/templates/org-plugin/skills/prime/SKILL.md.template
@@ -73,6 +73,11 @@ ls "$WIKI/decisions/"
 
 {{TRACKER_PRIME_SNIPPET}}
 
+When a ticket key was passed, also read its comments — prior decisions/refinements
+land there, not in the description, and the view above does not include them:
+
+{{TRACKER_COMMENT_LIST_SNIPPET}}
+
 ### 7. Load the project's repo index (the workspace top-level `CLAUDE.md`)
 
 If you started at a multi-repo workspace top level, read its `CLAUDE.md` — that is the

--- a/templates/org-plugin/skills/refine/SKILL.md.template
+++ b/templates/org-plugin/skills/refine/SKILL.md.template
@@ -34,6 +34,11 @@ at T1 first; promote to detail only when a specific decision needs it.
 
 {{TRACKER_VIEW_ISSUE_SNIPPET}}
 
+Also read the ticket's comments — prior decisions/refinements are recorded there, not
+in the description, and the view above does not include them:
+
+{{TRACKER_COMMENT_LIST_SNIPPET}}
+
 Surface: key, title, the user need / problem statement, current state. Don't pull
 the full body until a decision requires it.
 

--- a/tests/test_adapter_render.py
+++ b/tests/test_adapter_render.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Golden-render harness for tracker adapters (docs/ADAPTERS.md §"Adapter
+doctor self-tests").
+
+This is the anti-regression net the docs SPECIFIED but that was never built —
+the gap that let the jira-acli read-path ship comment-blind (no `comment list`
+in prime/refine/execute). See fix/acli-comment-read (PR1); this harness (PR2)
+encodes that contract as an executable test.
+
+What it does:
+  - builds org-tier bindings from a tiny fixture .forge.org.yaml wired to the
+    jira-acli adapter (lib.emit.build_bindings),
+  - renders the whole templates/org-plugin tree (lib.render.render_tree),
+  - SEMANTIC GUARD: asserts the rendered prime/refine/execute SKILL.md each
+    carry `comment list` in their ticket-read path (NOT comment-blind),
+  - asserts the full render completes with no unresolved {{placeholders}}
+    (render_tree raises SystemExit(2) on any survivor).
+
+Run:  uv run --with pytest --with pyyaml pytest tests/test_adapter_render.py -q
+
+Mirrors tests/test_model_policy_binding.py for import/style (sys.path → lib).
+"""
+import sys
+from pathlib import Path
+
+import yaml
+
+LIB = Path(__file__).resolve().parent.parent / "lib"
+sys.path.insert(0, str(LIB))
+import emit  # noqa: E402
+import render  # noqa: E402
+
+FORGE_ROOT = Path(__file__).resolve().parent.parent
+FIXTURE = FORGE_ROOT / "adapters/tracker/_test/sample.forge.org.yaml"
+TEMPLATES = FORGE_ROOT / "templates/org-plugin"
+
+# The rendered read-path skills (canonical verb names; the fixture sets no
+# `verbs:` overrides, so emit keeps these dir names).
+READ_PATH_SKILLS = ("prime", "refine", "execute")
+
+
+def _render(out_dir: Path) -> dict:
+    """Build bindings from the fixture, render the org-plugin tree, return
+    {skill_name: rendered SKILL.md text}. Raises SystemExit on any unresolved
+    placeholder (that IS assertion (c))."""
+    cfg = yaml.safe_load(FIXTURE.read_text())
+    bindings = emit.build_bindings(cfg)
+    render.render_tree(bindings, TEMPLATES, out_dir, FORGE_ROOT)
+    return {
+        name: (out_dir / "skills" / name / "SKILL.md").read_text()
+        for name in READ_PATH_SKILLS
+    }
+
+
+def test_read_path_skills_are_not_comment_blind(tmp_path):
+    """SEMANTIC GUARD (load-bearing): prime, refine, AND execute must each
+    inline `comment list` in their ticket-read path. This is what FAILS against
+    pre-PR1 state (the jira-acli adapter had no comment-read snippet) and PASSES
+    with PR1's fix wired in."""
+    skills = _render(tmp_path / "emit")
+    for name in READ_PATH_SKILLS:
+        assert "comment list" in skills[name], (
+            f"{name}/SKILL.md read path is COMMENT-BLIND: no `comment list` "
+            f"found. The adapter's read snippets must fetch comments — "
+            f"`view` excludes them. (Regression of fix/acli-comment-read.)"
+        )
+
+
+def test_full_render_has_no_unresolved_placeholders(tmp_path):
+    """Clean full render: render_tree raises SystemExit(2) if ANY {{...}}
+    survives. Reaching the assert means the whole org-plugin tree resolved."""
+    skills = _render(tmp_path / "emit")
+    # Belt-and-suspenders: no stray mustache tokens in the read-path output.
+    for name, text in skills.items():
+        assert "{{" not in text, f"{name}/SKILL.md has an unresolved placeholder"
+
+
+if __name__ == "__main__":
+    import tempfile
+
+    fns = [v for k, v in sorted(globals().items())
+           if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        with tempfile.TemporaryDirectory() as td:
+            try:
+                fn(Path(td))
+                print(f"PASS {fn.__name__}")
+            except AssertionError as e:
+                failed += 1
+                print(f"FAIL {fn.__name__}: {e}")
+            except Exception as e:  # noqa: BLE001
+                failed += 1
+                print(f"ERROR {fn.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## What

Builds the **adapter golden-render harness** that `docs/ADAPTERS.md` (§"Adapter doctor self-tests", ~L151-158) specified — *"The forge plugin's CI runs these to catch regressions"* — but which was never built. That missing harness is precisely the gap that let the `jira-acli` read-path ship **comment-blind** (no `comment list` in prime/refine/execute), the defect fixed in **PR1** (`fix/acli-comment-read`).

**Stacked on `fix/acli-comment-read`** so the harness validates against PR1's actual fix. Base of this PR = `fix/acli-comment-read` (not `main`).

## Changes

- `adapters/tracker/_test/sample.forge.org.yaml` — minimal fixture config wired to the `jira-acli` adapter. Provides exactly the keys `lib.emit.build_bindings` `require()`s, with non-example values (passes the identity gate).
- `tests/test_adapter_render.py` — pytest (mirrors `tests/test_model_policy_binding.py` import/style):
  - builds bindings via `lib.emit.build_bindings`, renders `templates/org-plugin` via `lib.render.render_tree` to a tmp dir; - **semantic guard (load-bearing):** asserts rendered `prime`, `refine`, **and** `execute` `SKILL.md` each contain `comment list` in their ticket-read path — i.e. the read path is not comment-blind; - asserts the full render completes with **no unresolved `{{placeholder}}`** (`render_tree` raises `SystemExit(2)` on any survivor).
- `.github/workflows/validate.yml` — adds an "Adapter render tests" step (via `uv`) after the existing Python-syntax / plugin-validation steps.
- `docs/ADAPTERS.md` — points the self-test section at the new harness.

## Golden vs. semantic

I chose the **semantic assertion** (`comment list` present in each rendered read-path skill) over whole-file golden snapshots. The semantic guard directly encodes the contract that broke and is robust to incidental template churn; pinning whole rendered files would churn on every unrelated copy edit and rot. Unresolved-placeholder detection (reused from `render_tree`) covers the structural "clean full render" half. No golden fragment files pinned.

## Verification — proven to be a real gate

```
# With PR1's fix present (this branch):
$ uv run --with pytest --with pyyaml pytest tests/ -q
......  6 passed

# Simulated pre-PR1 (checked out 953d232^:adapters/tracker/jira-acli.md — the
# comment-blind adapter), same test:
FAILED test_read_path_skills_are_not_comment_blind
FAILED test_full_render_has_no_unresolved_placeholders
2 failed   # TRACKER_COMMENT_LIST_SNIPPET label not found in adapter
```

The harness fails red without the fix and passes green with it. Adapter restored after the demonstration (no diff).

## TODO — published-side mirror guard (re-emit follow-up, NOT in this PR)

This harness guards the **generator** (forge). The **emitted** package repo `proscia-techops/proscia-hyperdrive` (CI: `.github/workflows/validate.yaml`, today only `claude plugin validate --strict` + an identity-leak grep) should carry an equivalent guard: a grep/test asserting the **published** skills' ticket-read paths include `comment list`. That repo is not checked out here and is intentionally **not** modified in this PR — flagging it as the re-emit follow-up.