### PR TITLE
TEC-3478: lean, progressively-disclosed, scope-aware prime (Org-default)

### DIFF
--- a/templates/org-plugin/skills/prime/SKILL.md.template
+++ b/templates/org-plugin/skills/prime/SKILL.md.template
@@ -17,12 +17,44 @@ Run this before `{{VERB_REFINE}}`, `{{VERB_EXECUTE}}`, or any real work.
 /prime [ticket-key]
 ```
 
-The optional ticket key narrows live state to one work item.
+The optional ticket key narrows live state to one work item. You do **not** have to
+declare a project — `{{VERB_PRIME}}` resolves scope for you (see step 0).
 
 ## What this skill does
 
-Follow these steps in order. **Read, don't pre-load everything** — pull T1 first,
-promote to detail only when a step needs it (progressive disclosure).
+`{{VERB_PRIME}}` is **lightweight by default**. Read **tier-1 only** up front —
+operating-model, schema/CLAUDE.md, compliance, the constitution-class ADRs — and pull
+live tracker state. **DEFER** deep per-project reads: promote to that detail only when a
+later step actually needs it (progressive disclosure, ADR-0003). Do not pre-load
+everything.
+
+Scope is **ambient context, not a prerequisite**. Org is the **default and first-class
+scope**; you never force the user to define a project. Resolve scope in step 0, then
+follow the steps in order — some are **project-mode-only** and are skipped in Org mode.
+
+### 0. Resolve scope — Org (default) or a specific project
+
+Before reading anything heavy, self-resolve the question **"am I on a project, or
+not?"** Check these sources, in order, and stop at the first that answers:
+
+- the **session ticket** (the `[ticket-key]` passed, if any) — its project/component;
+- the **repo** you started in (its remote / its local `CLAUDE.md`);
+- the **wiki** (project hub entries, if scope is named there);
+- a **handoff** note from a prior session (resume state);
+- the **tracker** itself (the ticket's project field / parent epic).
+
+Rules:
+
+- **Default to Org** when no source names a project, **or** when the work is
+  cross-cutting, SRE, or a one-off. Org is first-class — this is not "unfiled" or a
+  fallback-of-last-resort; it is the normal case.
+- **Never force a project declaration.** Resolve from the sources above; do not stop
+  and demand the user pick one.
+- **Escalate to a human ONLY** when scope is genuinely ambiguous *and* no source above
+  answers — and even then, proceed in **Org mode** unless told otherwise.
+
+Record the resolved scope; you will state it in the calibration summary (step 9) and it
+gates steps 7–8 below.
 
 ### 1. Locate the wiki
 
@@ -78,32 +110,39 @@ land there, not in the description, and the view above does not include them:
 
 {{TRACKER_COMMENT_LIST_SNIPPET}}
 
-### 7. Load the project's repo index (the workspace top-level `CLAUDE.md`)
+### 7. (PROJECT MODE ONLY) Load the project hub + repo index
 
-If you started at a multi-repo workspace top level, read its `CLAUDE.md` — that is the
-**project's own repo index**: which repos this project spans and what each is for.
-This lives with the project, **not** in the wiki (project structure is per-project; the
-wiki is the reusable org brain). It auto-loads as context when you start at the top
-level. `{{VERB_EXECUTE}}` scopes each task to one of these repos.
+**Skip this step entirely in Org mode.** The project-hub ADR and the workspace repo
+index are project-mode-only reads; in Org mode there is no project to index, so do not
+read them.
+
+In **project mode**, read the project's **repo index** — the workspace top-level
+`CLAUDE.md`. That is the **project's own repo index**: which repos this project spans
+and what each is for. It lives with the project, **not** in the wiki (project structure
+is per-project; the wiki is the reusable org brain). It auto-loads as context when you
+start at a multi-repo workspace top level. `{{VERB_EXECUTE}}` scopes each task to one of
+these repos. Promote any project-hub ADR to detail here only if this step needs it.
 
 ```bash
 test -f ./CLAUDE.md && cat ./CLAUDE.md   # the workspace repo index, if present
 ```
 
-### 8. Load repo context (only if working inside a single repo)
+### 8. (PROJECT MODE ONLY) Load single-repo context
 
-If this session is inside one repo, read that repo's local `CLAUDE.md` for
-repo-specific conventions, and skim `{{ORG_WIKI_NAME}}/learnings/` for known
-gotchas on that repo.
+**Skip this step in Org mode.** If this session is in **project mode** inside one repo,
+read that repo's local `CLAUDE.md` for repo-specific conventions, and skim
+`{{ORG_WIKI_NAME}}/learnings/` for known gotchas on that repo.
 
 ### 9. Emit a calibration summary
 
 State, in a few lines:
 
+- **Scope (Org | <project>):** the scope you resolved in step 0, and the source that
+  settled it (ticket / repo / wiki / handoff / tracker, or "defaulted to Org")
 - **Process I will follow:** the {{VERB_REFINE}}→{{VERB_EXECUTE}}→{{VERB_GATE}} flow as the wiki defines it today
 - **Hard rules in force:** the machine-checkable ones from the schema + constitution
 - **Compliance posture:** regulated guardrails that apply (or "none declared")
-- **Repos in scope:** the repos from the workspace repo index (or "single repo" / "none")
+- **Repos in scope:** in project mode, the repos from the workspace repo index (or "single repo"); in Org mode, "n/a — Org scope"
 - **Live state:** the ticket(s) in scope and their status
 - **Next concrete action:** what to do first
 

--- a/tests/test_prime_scope_aware.py
+++ b/tests/test_prime_scope_aware.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""TEC-3478 — prime is lean, progressively-disclosed, scope-aware (Org-default).
+
+Renders the org-plugin tree from a real (non-example) config and asserts the
+EMITTED prime SKILL.md exhibits the behavioral W2 half:
+  1. T1-only by default; deep per-project reads DEFERRED / progressive.
+  2. prime SELF-RESOLVES scope (ticket/repo/wiki/handoff/tracker) and only
+     ESCALATES to a human when no source answers — never forces a declaration.
+  3. defaults to ORG when scope is unresolved / cross-cutting / SRE / one-off.
+  4. ORG MODE skips the project-hub ADR + workspace repo-index (step 7) and the
+     single-repo load (step 8); those are PROJECT-MODE-ONLY.
+  5. calibration summary still emitted (step 9) and now carries a Scope line.
+
+Run:  uv run --with pyyaml python tests/test_prime_scope_aware.py
+"""
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "lib"))
+import emit  # noqa: E402
+from render import render_tree  # noqa: E402
+
+CFG = {
+    "org": {"name": "Testco", "slug": "testco"},
+    "plugin": {
+        "name": "testco-harness", "version": "0.1.0", "description": "d",
+        "author": {"name": "Testco Platform Engineering", "url": "https://github.com/testco"},
+        "homepage": "https://github.com/testco/testco-harness", "license": "UNLICENSED",
+    },
+    "org_wiki": {
+        "name": "testco-wiki", "remote": "git@github.com:testco/testco-wiki.git",
+        "local_path_env": "TESTCO_WIKI", "default_local_path": "~/work/testco-wiki",
+        "prime_reads": ["operating-model.md"],
+    },
+    "tracker": {"type": "jira-acli", "config": {
+        "cloud_id": "00000000-0000-0000-0000-000000000000",
+        "project_key": "TST", "base_url": "https://testco.atlassian.net",
+    }},
+    "agents": [
+        {"name": "implementer", "model": "sonnet"},
+        {"name": "reviewer", "model": "sonnet"},
+        {"name": "gate", "model": "sonnet"},
+    ],
+}
+
+
+def emit_prime() -> str:
+    bindings = emit.build_bindings(CFG)
+    tmp = Path(tempfile.mkdtemp(prefix="emit-verify-3478-test-"))
+    render_tree(bindings, ROOT / "templates/org-plugin", tmp, ROOT, leak_check=True)
+    # canonical skill dir is 'prime'; org may rename, but Testco uses defaults.
+    matches = list(tmp.rglob("skills/*prime*/SKILL.md")) or list(tmp.rglob("skills/prime/SKILL.md"))
+    assert matches, f"no emitted prime SKILL.md under {tmp}"
+    return matches[0].read_text()
+
+
+def test_leak_clean_and_no_unresolved():
+    # render_tree raises SystemExit on unresolved placeholders or identity leaks.
+    txt = emit_prime()
+    assert "{{" not in txt, "unresolved placeholder survived in emitted prime"
+    low = txt.lower()
+    assert "forge" not in low and "toulgaridis" not in low, "identity leak in emitted prime"
+
+
+def test_t1_only_by_default():
+    txt = emit_prime().lower()
+    assert "progressive" in txt or "defer" in txt, "no progressive-disclosure framing"
+    assert "tier-1" in txt or "t1" in txt, "T1 not named as the default read set"
+    # deep per-project reads must be explicitly deferred, not eager.
+    assert "promote" in txt and "detail" in txt, "no promote-to-detail-on-demand language"
+
+
+def test_self_resolves_scope():
+    txt = emit_prime().lower()
+    assert "resolve" in txt and "scope" in txt, "no scope-resolution step"
+    # the resolution sources must be named.
+    for src in ["ticket", "repo", "wiki", "handoff"]:
+        assert src in txt, f"scope-resolution source '{src}' not named"
+    # escalate to a human ONLY as last resort; never force a declaration.
+    assert "escalat" in txt, "no human-escalation fallback"
+    assert "not force" in txt or "never force" in txt or "without forcing" in txt, \
+        "does not promise NOT to force a project declaration"
+
+
+def test_defaults_to_org():
+    txt = emit_prime().lower()
+    assert "default" in txt and "org" in txt, "no org-default framing"
+    # cross-cutting / SRE / one-off work defaults to org.
+    assert "cross-cutting" in txt or "sre" in txt or "one-off" in txt, \
+        "cross-cutting/SRE/one-off org-default case missing"
+
+
+def test_project_reads_conditional():
+    txt = emit_prime().lower()
+    # both the project-hub-ish read and the repo-index/single-repo reads are
+    # gated on PROJECT MODE.
+    assert "project mode" in txt, "no explicit 'project mode' gating"
+    assert "skip" in txt and "org mode" in txt, "org mode does not skip project-only reads"
+    # repo index is named and gated.
+    assert "repo index" in txt, "workspace repo-index read not present"
+
+
+def test_calibration_summary_has_scope_line():
+    txt = emit_prime()
+    low = txt.lower()
+    assert "calibration summary" in low, "calibration summary contract lost"
+    # the new Scope line, formatted Scope (Org | <project>).
+    assert "scope (org" in low, "calibration summary missing 'Scope (Org | <project>)' line"
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {fn.__name__}: {e}")
+        except SystemExit as e:
+            failed += 1
+            print(f"FAIL {fn.__name__}: emit/render raised SystemExit: {e}")
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## What

Behavioral half of the already-shipped W2 principle: **Org is the DEFAULT and FIRST-CLASS scope; never force defining a project; scope is AMBIENT CONTEXT.** Edits only the prime skill template.

## Changes (templates/org-plugin/skills/prime/SKILL.md.template)

1. **T1-only by default** — read tier-1 (operating-model, schema/CLAUDE.md, compliance, constitution-class ADRs) + live tracker state up front; DEFER deep per-project reads, promote to detail on demand (ADR-0003 progressive disclosure).
2. **Self-resolve scope (new step 0)** — resolve Org-vs-project from the session ticket / repo / wiki / handoff / tracker; escalate to a human ONLY when no source answers; never force a project declaration.
3. **Default to Org** — when scope is unresolved or work is cross-cutting/SRE/one-off. Org is first-class, not "unfiled".
4. **Steps 7 & 8 are PROJECT-MODE-ONLY** — project hub + workspace repo-index (step 7) and single-repo load (step 8) are explicitly skipped in Org mode.
5. **Calibration summary (step 9)** gains a `Scope (Org | <project>)` line; preserves the existing contract.

Mustache placeholders ({{VERB_*}}, {{ORG_NAME}}, {{TRACKER_*_SNIPPET}}, etc.) intact.

## Verification (measured on RE-EMIT)

- New `tests/test_prime_scope_aware.py` renders the org-plugin tree from a real (non-example) config and asserts the EMITTED prime SKILL.md is T1-only-by-default, self-resolves scope, defaults to Org, gates steps 7/8 on project mode, and carries the Scope line. **6/6 pass.**
- Re-emitted to a fresh temp dir (`lib/emit.py --out /tmp/emit-verify-3478`): **leak gate clean**, no unresolved placeholders.
- Full suite green (adapter-render + model-policy + prime-scope).

Scope boundary: forge SOURCE / upstream personal work; adapter snippets untouched (TEC-3416's territory).