### PR TITLE
feat(tracker/jira): derive board/project from ticket-key prefix (multi-board)

### DIFF
--- a/adapters/tracker/jira-acli.md
+++ b/adapters/tracker/jira-acli.md
@@ -26,19 +26,26 @@ adapter supplies the snippets the org-plugin skills inline.
 ## Skill snippets
 
 These map to the `{{TRACKER_*_SNIPPET}}` placeholders in `templates/org-plugin/`.
-`project_key` is substituted from `.forge.org.yaml`. Verbs validated against `acli`
-v1.3.19.
+`project_key` is an OPTIONAL default board from `.forge.org.yaml` — my-work and the
+swarm-ready gate span every board you can see, and single-ticket lookups derive their
+board from the ticket KEY PREFIX at runtime. Verbs validated against `acli` v1.3.19.
 
 ### `TRACKER_PRIME_SNIPPET`
 
 ```bash
-# My in-flight work (CSV so the agent can read it back without ADF noise):
+# My in-flight work, ACROSS EVERY board I can see (CSV so the agent can read it
+# back without ADF noise). Do NOT pin one project — an engineer's work spans
+# multiple boards; the assignee filter already scopes it to me:
 acli jira workitem search \
-  --jql "project = {{tracker.config.project_key}} AND assignee = currentUser() AND statusCategory != Done ORDER BY updated DESC" \
-  --fields key,status,summary --csv
+  --jql "assignee = currentUser() AND statusCategory != Done ORDER BY updated DESC" \
+  --fields key,status,summary,project --csv
+#   (Optionally narrow to a default board with `project = {{tracker.config.project_key}} AND …`
+#    — but that is an OPTIONAL scope, not the default. My-work spans all my boards.)
 
-# A specific ticket (if a key was passed):
-acli jira workitem view <key> --fields summary,status,labels
+# A specific ticket (if a key was passed): the board/project is DERIVED FROM THE
+# KEY PREFIX at runtime (e.g. TEC-3416 → project TEC), so any board works without
+# a hardcoded config value. Jira keys are globally unique, so `view` resolves it:
+acli jira workitem view <key> --fields summary,status,labels,project
 ```
 
 Surface results at T1 (key, summary, status); pull full bodies only when a step needs them.
@@ -78,10 +85,14 @@ acli jira workitem comment create --key <key> --body-file ./update.md
 acli jira workitem view <a-sibling-child-of-the-story> --fields issuetype --json
 #   → read the issuetype name from the JSON and use it verbatim as <child-type>.
 
+# A child lives on the SAME board as its parent story. DERIVE the project from the
+# parent's KEY PREFIX (e.g. <story-key> TEC-3400 → project TEC) rather than a
+# hardcoded config value, so this works on whichever board the story lives on:
+PROJECT="${STORY_KEY%%-*}"   # key prefix before the first '-' is the project key
 acli jira workitem create \
-  --project {{tracker.config.project_key}} \
+  --project "$PROJECT" \
   --type "<child-type>" \
-  --parent <story-key> \
+  --parent "$STORY_KEY" \
   --summary "<repo>: <concern>" \
   --description "<acceptance criteria + test expectations + constraints + deps>"
 
@@ -92,11 +103,14 @@ acli jira workitem create \
 ### `TRACKER_BACKLOG_SNIPPET`
 
 ```bash
-# Find swarm-ready work: the refine→execute gate is carried by the board-agnostic
-# `agent-ready` LABEL (see TRACKER_GATE_SNIPPET), not a board-specific status.
+# Find swarm-ready work ACROSS EVERY board I can see: the refine→execute gate is
+# carried by the board-agnostic `agent-ready` LABEL (see TRACKER_GATE_SNIPPET),
+# not a board-specific status — so do NOT pin one project. Each result's project
+# (its key prefix) tells you which board it lives on:
 acli jira workitem search \
-  --jql "project = {{tracker.config.project_key}} AND labels = agent-ready AND statusCategory != Done" \
-  --fields key,status,summary --csv
+  --jql "labels = agent-ready AND statusCategory != Done" \
+  --fields key,status,summary,project --csv
+#   (Optionally narrow to one board with `project = {{tracker.config.project_key}} AND …`.)
 ```
 
 When ORIGINATING a backlog tree (epics + their stories), do NOT assume issue-type names
@@ -161,3 +175,8 @@ acli jira auth status \
   you need a ticket's full state (prior decisions/refinements/PR/VERDICT lines).
 - Add `--json` on `view` when you need to parse fields (e.g. issuetype discovery);
   prefer `--csv` on `search` for compact, parseable list output.
+- **Board-from-key (multi-board).** My-work and backlog searches span every board the
+  user can see (scoped by `assignee`/label, not `project`). A single-ticket lookup and
+  child-task creation DERIVE their board/project from the ticket KEY PREFIX
+  (`TEC-3416` → `TEC`) at runtime, since Jira keys are globally unique. `project_key`
+  in config is an OPTIONAL default to narrow a query, never a hard filter on my-work.

--- a/adapters/tracker/jira-mcp.md
+++ b/adapters/tracker/jira-mcp.md
@@ -27,15 +27,22 @@ skills inline.
 ## Skill snippets
 
 These map to the `{{TRACKER_*_SNIPPET}}` placeholders in `templates/org-plugin/`.
-`cloud_id` / `project_key` are substituted from `.forge.org.yaml`.
+`cloud_id` is substituted from `.forge.org.yaml`; `project_key` is an OPTIONAL default
+board only (my-work and the swarm-ready gate span every board you can see, and
+single-ticket lookups derive their board from the ticket KEY PREFIX at runtime).
 
 ### `TRACKER_PRIME_SNIPPET`
 
 ```
 Pull live state via the Atlassian MCP (cloudId `{{tracker.config.cloud_id}}`):
-- My in-flight work:
-  searchJiraIssuesUsingJql — jql: "project = {{tracker.config.project_key}} AND assignee = currentUser() AND statusCategory != Done ORDER BY updated DESC"
-- A specific ticket (if a key was passed):
+- My in-flight work, ACROSS EVERY board I can see — do NOT pin one project; the
+  assignee filter already scopes it to me, and an engineer's work spans multiple boards:
+  searchJiraIssuesUsingJql — jql: "assignee = currentUser() AND statusCategory != Done ORDER BY updated DESC"
+    (Optionally narrow to a default board by prefixing `project = {{tracker.config.project_key}} AND …`
+     — an OPTIONAL scope, not the default. My-work spans all my boards.)
+- A specific ticket (if a key was passed): the board/project is DERIVED FROM THE KEY
+  PREFIX at runtime (e.g. TEC-3416 → project TEC); Jira keys are globally unique, so no
+  hardcoded config value is needed to resolve it:
   getJiraIssue — issueIdOrKey: <ticket-key>, responseContentFormat: "markdown"
 Surface results at T1 (key, summary, status); pull full bodies only when a step needs them.
 ```
@@ -63,11 +70,13 @@ Persist to the ticket via the Atlassian MCP:
 ### `TRACKER_CREATE_TASK_SNIPPET`
 
 ```
-Create a child task via the Atlassian MCP. Don't assume the project's hierarchy —
-discover it, then create the right type:
-  getJiraProjectIssueTypesMetadata — cloudId: "{{tracker.config.cloud_id}}", projectIdOrKey: "{{tracker.config.project_key}}"
+Create a child task via the Atlassian MCP. A child lives on the SAME board as its
+parent story, so DERIVE the project from the parent's KEY PREFIX (e.g. <story-key>
+TEC-3400 → project TEC) rather than a hardcoded config value. Don't assume the
+project's hierarchy either — discover it, then create the right type:
+  getJiraProjectIssueTypesMetadata — cloudId: "{{tracker.config.cloud_id}}", projectIdOrKey: "<key-prefix of <story-key>>"
     → pick the child type this project uses under a story (Sub-task, or Task with a parent).
-  createJiraIssue — cloudId: "{{tracker.config.cloud_id}}", projectKey: "{{tracker.config.project_key}}",
+  createJiraIssue — cloudId: "{{tracker.config.cloud_id}}", projectKey: "<key-prefix of <story-key>>",
                     issueTypeName: "<discovered child type>", parent: "<story-key>", summary: "<repo>: <concern>",
                     description: "<acceptance criteria + test expectations + constraints + deps>"
 Link dependencies with createIssueLink (type "Blocks") to encode the DAG.
@@ -76,17 +85,20 @@ Link dependencies with createIssueLink (type "Blocks") to encode the DAG.
 ### `TRACKER_BACKLOG_SNIPPET`
 
 ```
-Originate a backlog tree (epics + their stories) via the Atlassian MCP. Discover the
-project's hierarchy first — don't assume Epic/Story exist by those names:
-  getJiraProjectIssueTypesMetadata — cloudId: "{{tracker.config.cloud_id}}", projectIdOrKey: "{{tracker.config.project_key}}"
+Originate a backlog tree (epics + their stories) via the Atlassian MCP. Origination
+targets ONE board — the one you're seeding — so pick the target project key here
+(`{{tracker.config.project_key}}` is a sensible default, but use whichever board this
+initiative lives on). Discover that project's hierarchy first — don't assume Epic/Story
+exist by those names:
+  getJiraProjectIssueTypesMetadata — cloudId: "{{tracker.config.cloud_id}}", projectIdOrKey: "<target project key>"
     → identify the top breakdown type (often "Epic") and the story-level type (often "Story").
 
-Create an epic:
-  createJiraIssue — cloudId: "{{tracker.config.cloud_id}}", projectKey: "{{tracker.config.project_key}}",
+Create an epic (projectKey = the target board you picked above):
+  createJiraIssue — cloudId: "{{tracker.config.cloud_id}}", projectKey: "<target project key>",
                     issueTypeName: "<epic type>", summary: "<epic title>",
                     description: "<the slice of the initiative this epic delivers>"
-Create a story under it (parent = the epic key):
-  createJiraIssue — cloudId: "{{tracker.config.cloud_id}}", projectKey: "{{tracker.config.project_key}}",
+Create a story under it (parent = the epic key; same board as its epic):
+  createJiraIssue — cloudId: "{{tracker.config.cloud_id}}", projectKey: "<key-prefix of <epic-key>>",
                     issueTypeName: "<story type>", parent: "<epic-key>", summary: "a <user> needs to <do X>",
                     description: "<user need + which repos it touches + a first cut at the acceptance test>"
 Encode ordering/dependencies between epics or stories with createIssueLink (type "Blocks").
@@ -109,8 +121,10 @@ The harness owns a small label namespace:
 
 Read the gate (does this ticket carry the label?):
   getJiraIssue — cloudId: "{{tracker.config.cloud_id}}", issueIdOrKey: <key>, fields: ["labels","summary","status"]
-Find all swarm-ready work on this board:
-  searchJiraIssuesUsingJql — jql: "project = {{tracker.config.project_key}} AND labels = agent-ready AND statusCategory != Done"
+Find all swarm-ready work ACROSS EVERY board you can see — the label is board-agnostic,
+so do NOT pin one project; each result's key prefix tells you which board it lives on:
+  searchJiraIssuesUsingJql — jql: "labels = agent-ready AND statusCategory != Done"
+    (Optionally narrow to one board by prefixing `project = {{tracker.config.project_key}} AND …`.)
 Apply/clear the gate label (preserve existing labels — add, don't overwrite):
   editJiraIssue — cloudId: "{{tracker.config.cloud_id}}", issueIdOrKey: <key>, fields: { "labels": [<existing...>, "agent-ready"] }
 
@@ -136,3 +150,8 @@ resolve). If they don't, run /mcp to reconnect. Verify access:
 - The MCP sometimes needs a `/mcp` reconnect before its tools surface.
 - For Jira ADF vs markdown bodies, prefer `responseContentFormat: "markdown"` on reads
   and `contentFormat: "markdown"` on writes unless full ADF fidelity is needed.
+- **Board-from-key (multi-board).** My-work and the swarm-ready gate search span every
+  board the user can see (scoped by `assignee`/label, not `project`). Single-ticket
+  lookups and child-task creation DERIVE their board/project from the ticket KEY PREFIX
+  (`TEC-3416` → `TEC`) at runtime, since Jira keys are globally unique. `project_key` in
+  config is an OPTIONAL default to narrow a query, never a hard filter on my-work.

--- a/tests/test_adapter_render.py
+++ b/tests/test_adapter_render.py
@@ -66,6 +66,41 @@ def test_read_path_skills_are_not_comment_blind(tmp_path):
         )
 
 
+def test_prime_my_work_does_not_hard_filter_one_project(tmp_path):
+    """BOARD-FROM-KEY (TEC-3416): the prime my-work query must span the boards
+    the user can see, NOT hard-filter `project = <one key>`. The fixture's
+    project_key (FIX) may survive only as an OPTIONAL default/example, never as
+    a hard filter on the my-work search.
+
+    FAILS against the pre-3416 adapter (`project = FIX AND assignee =
+    currentUser()`); PASSES once my-work drops the single-project filter."""
+    skills = _render(tmp_path / "emit")
+    prime = skills["prime"]
+    my_work_clause = "assignee = currentUser() AND statusCategory != Done"
+    assert my_work_clause in prime, "prime my-work query changed shape unexpectedly"
+    # The my-work line must not pin a single project. Check every line that
+    # carries the my-work clause: none may also carry `project = <KEY>`.
+    for line in prime.splitlines():
+        if my_work_clause in line:
+            assert "project = " not in line, (
+                "prime my-work query HARD-FILTERS one project: "
+                f"{line.strip()!r}. It must span all boards the user can see "
+                "(board-from-key), not pin a single project_key."
+            )
+
+
+def test_single_lookup_derives_board_from_key_prefix(tmp_path):
+    """BOARD-FROM-KEY (TEC-3416): a single-ticket lookup must derive its
+    board/project from the ticket KEY PREFIX at runtime, not a config value.
+    The adapter prose must say so (key-prefix → project)."""
+    skills = _render(tmp_path / "emit")
+    prime = skills["prime"].lower()
+    assert "key prefix" in prime or "key-prefix" in prime, (
+        "prime does not explain that a single-ticket lookup derives its "
+        "board/project from the ticket KEY PREFIX at runtime."
+    )
+
+
 def test_full_render_has_no_unresolved_placeholders(tmp_path):
     """Clean full render: render_tree raises SystemExit(2) if ANY {{...}}
     survives. Reaching the assert means the whole org-plugin tree resolved."""


### PR DESCRIPTION
## TEC-3416 — board/project derives from the ticket-KEY PREFIX (multi-board)

### Problem
The Jira tracker adapters (`jira-acli`, `jira-mcp`) hard-filtered every query to one configured `project_key`. So `prime`'s my-work view and the swarm-ready (`agent-ready`) gate only ever saw a single board. That is the gate blocking onboarding of engineers/teams whose work spans multiple boards.

### Change (adapter snippets only — `adapters/tracker/`)
- **my-work + swarm-ready gate now span EVERY board the user can see** — scoped by `assignee = currentUser()` / `labels = agent-ready`, not by `project`. `project_key` survives only as an OPTIONAL narrowing default (shown in a comment), never as a hard filter.
- **single-ticket lookups + child-task creation DERIVE their board/project from the ticket KEY PREFIX** at runtime (`TEC-3416` -> project `TEC`). Jira keys are globally unique, so no hardcoded config value is needed. acli uses `${STORY_KEY%%-*}`; mcp uses `<key-prefix of <story-key>>`.
- Reuses `jira-multi.md`'s multi-board idea (one queue across boards) without duplicating its config schema.

### Tests (TDD)
Two new semantic guards added to the existing adapter golden-render harness (`tests/test_adapter_render.py`), written failing-first against the pre-change adapters:
- `test_prime_my_work_does_not_hard_filter_one_project` — no emitted my-work line may carry `project = <KEY>`.
- `test_single_lookup_derives_board_from_key_prefix` — prime must explain key-prefix derivation.

All 8 tests pass. Re-emit verified: emitted `prime` my-work query no longer hard-filters one project (only an OPTIONAL-marked comment mentions the default key), single lookups derive board-from-key, and the emitted tree is leak-clean.

Closes TEC-3416.