### PR TITLE
docs(adapters): neutral placeholder keys in jira example prose

### DIFF
--- a/adapters/tracker/jira-acli.md
+++ b/adapters/tracker/jira-acli.md
@@ -43,7 +43,7 @@ acli jira workitem search \
 #    — but that is an OPTIONAL scope, not the default. My-work spans all my boards.)
 
 # A specific ticket (if a key was passed): the board/project is DERIVED FROM THE
-# KEY PREFIX at runtime (e.g. TEC-3416 → project TEC), so any board works without
+# KEY PREFIX at runtime (e.g. ABC-123 → project ABC), so any board works without
 # a hardcoded config value. Jira keys are globally unique, so `view` resolves it:
 acli jira workitem view <key> --fields summary,status,labels,project
 ```
@@ -86,7 +86,7 @@ acli jira workitem view <a-sibling-child-of-the-story> --fields issuetype --json
 #   → read the issuetype name from the JSON and use it verbatim as <child-type>.
 
 # A child lives on the SAME board as its parent story. DERIVE the project from the
-# parent's KEY PREFIX (e.g. <story-key> TEC-3400 → project TEC) rather than a
+# parent's KEY PREFIX (e.g. <story-key> ABC-123 → project ABC) rather than a
 # hardcoded config value, so this works on whichever board the story lives on:
 PROJECT="${STORY_KEY%%-*}"   # key prefix before the first '-' is the project key
 acli jira workitem create \
@@ -178,5 +178,5 @@ acli jira auth status \
 - **Board-from-key (multi-board).** My-work and backlog searches span every board the
   user can see (scoped by `assignee`/label, not `project`). A single-ticket lookup and
   child-task creation DERIVE their board/project from the ticket KEY PREFIX
-  (`TEC-3416` → `TEC`) at runtime, since Jira keys are globally unique. `project_key`
+  (`ABC-123` → `ABC`) at runtime, since Jira keys are globally unique. `project_key`
   in config is an OPTIONAL default to narrow a query, never a hard filter on my-work.

--- a/adapters/tracker/jira-mcp.md
+++ b/adapters/tracker/jira-mcp.md
@@ -41,7 +41,7 @@ Pull live state via the Atlassian MCP (cloudId `{{tracker.config.cloud_id}}`):
     (Optionally narrow to a default board by prefixing `project = {{tracker.config.project_key}} AND …`
      — an OPTIONAL scope, not the default. My-work spans all my boards.)
 - A specific ticket (if a key was passed): the board/project is DERIVED FROM THE KEY
-  PREFIX at runtime (e.g. TEC-3416 → project TEC); Jira keys are globally unique, so no
+  PREFIX at runtime (e.g. ABC-123 → project ABC); Jira keys are globally unique, so no
   hardcoded config value is needed to resolve it:
   getJiraIssue — issueIdOrKey: <ticket-key>, responseContentFormat: "markdown"
 Surface results at T1 (key, summary, status); pull full bodies only when a step needs them.
@@ -72,7 +72,7 @@ Persist to the ticket via the Atlassian MCP:
 ```
 Create a child task via the Atlassian MCP. A child lives on the SAME board as its
 parent story, so DERIVE the project from the parent's KEY PREFIX (e.g. <story-key>
-TEC-3400 → project TEC) rather than a hardcoded config value. Don't assume the
+ABC-123 → project ABC) rather than a hardcoded config value. Don't assume the
 project's hierarchy either — discover it, then create the right type:
   getJiraProjectIssueTypesMetadata — cloudId: "{{tracker.config.cloud_id}}", projectIdOrKey: "<key-prefix of <story-key>>"
     → pick the child type this project uses under a story (Sub-task, or Task with a parent).
@@ -153,5 +153,5 @@ resolve). If they don't, run /mcp to reconnect. Verify access:
 - **Board-from-key (multi-board).** My-work and the swarm-ready gate search span every
   board the user can see (scoped by `assignee`/label, not `project`). Single-ticket
   lookups and child-task creation DERIVE their board/project from the ticket KEY PREFIX
-  (`TEC-3416` → `TEC`) at runtime, since Jira keys are globally unique. `project_key` in
+  (`ABC-123` → `ABC`) at runtime, since Jira keys are globally unique. `project_key` in
   config is an OPTIONAL default to narrow a query, never a hard filter on my-work.


### PR DESCRIPTION
## Why

The `jira-acli` and `jira-mcp` adapter docs used **real-looking ticket keys** (`TEC-3416` / `TEC-3400`) as illustrative examples of board-from-key derivation. forge is a neutral generator: when it re-emits the org plugin, those literal keys land verbatim in skill files **and the emitted PR body**. Jira's "a PR that mentions `TEC-NNNN` advances that issue" automation then fired on the example key and **falsely moved an unrelated real ticket (TEC-3400) to Resolution Review**.

## What

Replace every illustrative example key in adapter prose with an obviously-fake neutral placeholder:

- `TEC-3416 → project TEC`  →  `ABC-123 → project ABC`
- `<story-key> TEC-3400 → project TEC`  →  `<story-key> ABC-123 → project ABC`

`ABC` / `ABC-123` is correct precisely because it is clearly not a real key, so a re-emit can never collide with any org's tracker.

## Scope guardrails

- **Only human-readable EXAMPLE keys** in comments/prose changed (6 lines total across 2 files).
- `{{tracker.config.project_key}}` template placeholders — untouched.
- `${STORY_KEY%%-*}` / key-prefix derivation logic — untouched.
- `grep -rnE 'TEC-[0-9]{3,4}' adapters/` now returns **zero** matches.
- Adapter golden-render / prime tests stay green (`14 passed`).