### PR TITLE
feat(emit): add DSH (DeepSeek Harness) as a second emit target

### DIFF
--- a/.forge.org.example.yaml
+++ b/.forge.org.example.yaml
@@ -154,20 +154,30 @@ dsh:
     provider: bedrock-claude
     model: your-anthropic-model-id       # a model id served by the route (example)
 
+  # How the emitted routes authenticate to the gateway. Default `sigv4`: every
+  # request is signed with AWS credentials from the harness's ambient chain
+  # (SSO/role), auto-refreshing — nothing to mint, store, or leak. Set `bearer`
+  # for a gateway fronted by a static token in an env var (the fallback).
+  auth: sigv4                       # sigv4 (default) | bearer
+
   # Provider routes for the pi-ai multi-provider adapter (config-only). Each route
-  # names a wire shape (`api`), a base URL, and an env-name that holds the token
+  # names a wire shape (`api`) and a base URL. Under `sigv4`, each route also names
+  # its AWS `region` (and optional `service`, default `bedrock-mantle`) — no token.
+  # Under `bearer`, each route names `apiKeyEnv`, an env-name that holds the token
   # (NEVER the token itself). The two shapes below illustrate one Anthropic-style
   # and one OpenAI-style route through a Bedrock gateway; keep only what you use.
   providers:
     - route: bedrock-claude
       api: anthropic-messages
       baseURL: https://bedrock-mantle.us-east-1.api.aws/anthropic   # {region} is yours
-      apiKeyEnv: MANTLE_TOKEN            # env-name ONLY — the token is never inlined
+      region: us-east-1                 # sigv4: the signing region (service defaults bedrock-mantle)
+      # apiKeyEnv: MANTLE_TOKEN         # bearer only — env-name ONLY, the token is never inlined
       model: your-anthropic-model-id
     - route: bedrock-gpt
       api: openai-responses
       baseURL: https://bedrock-mantle.us-east-1.api.aws/openai/v1
-      apiKeyEnv: MANTLE_TOKEN
+      region: us-east-1
+      # apiKeyEnv: MANTLE_TOKEN         # bearer only
       model: your-openai-model-id
 
   # The three delegation subagents the emitted engage skill dispatches by name.

--- a/.forge.org.example.yaml
+++ b/.forge.org.example.yaml
@@ -134,3 +134,64 @@ integrations:
   # - type: chat
   #   name: slack
   #   config: { workspace: acme, channels: { blockers: agent-blockers } }
+
+# --- DSH target: the DeepSeek Harness host shell (OPTIONAL) ------------------
+# Read ONLY by `/forge:emit --target dsh`. Everything above is shared: the same
+# operating model, wiki pointers, tracker, verbs, and model policy drive BOTH the
+# default `--target claude-code` plugin AND this DeepSeek Harness profile bundle.
+# The `dsh:` block adds only the host-shell bindings the DSH bundle needs — the
+# emitted skills are byte-identical to the Claude Code target. Omit this block
+# entirely if you don't emit a DSH bundle. All values are the ORG's / example
+# placeholders; no generator identity, no credentials (env-name references only).
+dsh:
+  bundle:
+    scope: '@acme'                 # YOUR org's npm scope for the emitted bundle
+    package: dsh-acme-harness      # -> @acme/dsh-acme-harness (defaults to dsh-<plugin.name>)
+
+  # Override the base's default DeepSeek model so entry-point Agents run on your
+  # provider. `provider` must be one of the `providers:` routes below.
+  default_model:
+    provider: bedrock-claude
+    model: your-anthropic-model-id       # a model id served by the route (example)
+
+  # Provider routes for the pi-ai multi-provider adapter (config-only). Each route
+  # names a wire shape (`api`), a base URL, and an env-name that holds the token
+  # (NEVER the token itself). The two shapes below illustrate one Anthropic-style
+  # and one OpenAI-style route through a Bedrock gateway; keep only what you use.
+  providers:
+    - route: bedrock-claude
+      api: anthropic-messages
+      baseURL: https://bedrock-mantle.us-east-1.api.aws/anthropic   # {region} is yours
+      apiKeyEnv: MANTLE_TOKEN            # env-name ONLY — the token is never inlined
+      model: your-anthropic-model-id
+    - route: bedrock-gpt
+      api: openai-responses
+      baseURL: https://bedrock-mantle.us-east-1.api.aws/openai/v1
+      apiKeyEnv: MANTLE_TOKEN
+      model: your-openai-model-id
+
+  # The three delegation subagents the emitted engage skill dispatches by name.
+  # The read-only tool filter is the LOAD-BEARING control: reviewer and clearance
+  # get exactly [read, grep, glob] (edit/write/bash absent by omission → refused);
+  # the implementer has NO filter, so it inherits the full read/write/shell set.
+  # maxDepth is an ABSOLUTE cap (child depth = parent + 1); the orchestrator is at
+  # depth 0, so a spawnable child needs maxDepth >= 1 (0 is un-spawnable).
+  subagents:
+    implementer:
+      toolName: subagent_implement
+      maxDepth: 1
+      persona: "You are subagent_implement: a TDD implementer with the full file and shell tool set. You never review your own work."
+    reviewer:
+      toolName: subagent_review
+      maxDepth: 1
+      toolFilter: { allow: [read, grep, glob] }
+      persona: "You are subagent_review: a read-only reviewer. You cannot modify files."
+    clearance:
+      toolName: subagent_clearance
+      maxDepth: 1
+      toolFilter: { allow: [read, grep, glob] }
+      persona: "You are subagent_clearance: a read-only gate validator. You check a ticket or PR against the wiki's current gate rules and return a pass/fail verdict plus a deficiency list. You never edit the ticket, the spec, or the code, and you never waive a gate."
+
+  # Which shared skills to fold into the bundle (canonical names; emit renames the
+  # output dirs to your verbs). Here: all skill verbs except `gate` (a role, not a skill).
+  skills: [intro, setup, prime, inception, refine, execute, wiki, handoff]

--- a/adapters/tracker/_test/sample.forge.org.yaml
+++ b/adapters/tracker/_test/sample.forge.org.yaml
@@ -48,11 +48,12 @@ dsh:
   default_model:
     provider: gw-claude
     model: fixture-anthropic-model
+  auth: sigv4
   providers:
     - route: gw-claude
       api: anthropic-messages
       baseURL: https://gateway.example.test/anthropic
-      apiKeyEnv: GW_TOKEN
+      region: us-east-1
       model: fixture-anthropic-model
   subagents:
     implementer:

--- a/adapters/tracker/_test/sample.forge.org.yaml
+++ b/adapters/tracker/_test/sample.forge.org.yaml
@@ -38,3 +38,35 @@ agents:
     model: opus
   - name: gate
     model: opus
+
+# DSH target keys — exercised by tests/test_dsh_emit.py (build_bindings_dsh /
+# emit_dsh). Neutral placeholder values; env-name reference only, no credentials.
+dsh:
+  bundle:
+    scope: '@fixtureco'
+    package: dsh-fixtureco-harness
+  default_model:
+    provider: gw-claude
+    model: fixture-anthropic-model
+  providers:
+    - route: gw-claude
+      api: anthropic-messages
+      baseURL: https://gateway.example.test/anthropic
+      apiKeyEnv: GW_TOKEN
+      model: fixture-anthropic-model
+  subagents:
+    implementer:
+      toolName: subagent_implement
+      maxDepth: 1
+      persona: "Fixture implementer (full tools)."
+    reviewer:
+      toolName: subagent_review
+      maxDepth: 1
+      toolFilter: { allow: [read, grep, glob] }
+      persona: "Fixture reviewer (read-only)."
+    clearance:
+      toolName: subagent_clearance
+      maxDepth: 1
+      toolFilter: { allow: [read, grep, glob] }
+      persona: "Fixture clearance (read-only)."
+  skills: [prime, execute]

--- a/commands/emit.md
+++ b/commands/emit.md
@@ -17,12 +17,21 @@ how *this* org works, owned entirely by the org.
 ## Invocation
 
 ```
-/forge:emit [--config <path>] [--out <dir>]
+/forge:emit [--config <path>] [--out <dir>] [--target claude-code|dsh]
 ```
 
 - `--config` — the org-tier config. Defaults to `./.forge.org.yaml`
   (see `.forge.org.example.yaml` for the shape).
 - `--out` — where to write the package. Defaults to `../<plugin.name>`.
+- `--target` — which host to emit for. Defaults to `claude-code` (a Claude Code
+  plugin: `.claude-plugin/` + `agents/` + `skills/` + `hooks/`). `dsh` emits a
+  **DeepSeek Harness** profile bundle (`cordis.patch.yml` + `package.json`) from
+  the SAME config: `build_bindings_dsh` reuses `build_bindings` wholesale and the
+  shared operating-model skills are folded in via a second `clean=False` render
+  pass, so only the host shell differs — one `.forge.org.yaml`, two emits. The
+  `dsh:` section of the config supplies the DSH-only keys (provider routes, the
+  read-only `toolFilter` on reviewer/clearance, the default model); see the
+  `dsh:` block in `.forge.org.example.yaml`.
 
 ## What this command does
 
@@ -33,7 +42,7 @@ engine `/forge:new` uses (`lib/render.py`), driven for the org tier by `lib/emit
 
 ```bash
 uv run --with pyyaml python lib/emit.py \
-  --config .forge.org.yaml --out ../<plugin.name>
+  --config .forge.org.yaml --out ../<plugin.name> [--target claude-code|dsh]
 ```
 
 `lib/emit.py` performs steps 1–5; step 6 is `claude plugin validate`. Read on for

--- a/commands/emit.md
+++ b/commands/emit.md
@@ -31,7 +31,10 @@ how *this* org works, owned entirely by the org.
   pass, so only the host shell differs — one `.forge.org.yaml`, two emits. The
   `dsh:` section of the config supplies the DSH-only keys (provider routes, the
   read-only `toolFilter` on reviewer/clearance, the default model); see the
-  `dsh:` block in `.forge.org.example.yaml`.
+  `dsh:` block in `.forge.org.example.yaml`. `dsh.auth` selects how the routes
+  authenticate: `sigv4` (default) signs each request with AWS credentials from
+  the harness's ambient chain — each route emits a `sigv4: {service, region}`
+  block and no token — while `bearer` emits the `apiKeyEnv` reference path.
 
 ## What this command does
 

--- a/lib/emit.py
+++ b/lib/emit.py
@@ -141,7 +141,12 @@ def build_bindings(cfg: dict) -> dict:
             "AGENT_GATE_EFFORT": agent_field(cfg, "gate", "effort", "medium"),
         },
         "arrays": {"PRIME_READS": wiki["prime_reads"]},
-        "conditionals": {},
+        # Host-target conditionals. The Claude Code emit is the default target, so
+        # TARGET_CC is on and TARGET_DSH off here; build_bindings_dsh() flips them.
+        # Shared skills use {{#TARGET_CC}}/{{#TARGET_DSH}} to diverge ONLY the
+        # host-specific dispatch mechanism (see the engage/execute skill), keeping
+        # the invariant (implement/review split, read-only reviewer) in shared prose.
+        "conditionals": {"TARGET_CC": True, "TARGET_DSH": False},
         "snippets": [
             {"placeholder": p, "adapter": adapter, "label": p, "vars": snippet_vars}
             for p in ("TRACKER_PRIME_SNIPPET", "TRACKER_VIEW_ISSUE_SNIPPET",
@@ -152,20 +157,87 @@ def build_bindings(cfg: dict) -> dict:
     }
 
 
-def main(argv=None):
-    ap = argparse.ArgumentParser(description="forge emit driver")
-    ap.add_argument("--config", default=".forge.org.yaml")
-    ap.add_argument("--out", required=True)
-    args = ap.parse_args(argv)
+# --- DSH (DeepSeek Harness) target ------------------------------------------
+# A second emit target: instead of a Claude Code plugin, render a DSH *profile
+# bundle* that patches over @deepseek-ai/dsh-base. Only the host-shell bindings
+# differ — the operating model (the shared skills) is byte-identical and reused
+# via a second render pass. DSH-only keys (provider routes, per-subagent tool
+# filters, the default model) come from the config's `dsh:` section.
 
-    cfg = yaml.safe_load(Path(args.config).read_text())
+def build_bindings_dsh(cfg: dict) -> dict:
+    """Org bindings (for the shared skills) plus DSH host-shell bindings.
+
+    Reuses build_bindings(cfg) wholesale so the rendered skills are identical to
+    the Claude Code target, then layers the scalars/arrays the DSH bundle
+    templates need (the bundle package name, the two Mantle routes, the default
+    model, and the reviewer/implementer subagent rows)."""
+    dsh = cfg.get("dsh")
+    require(dsh is not None, "target 'dsh' needs a `dsh:` section in the config")
+
+    base = build_bindings(cfg)
+
+    bundle = dsh.get("bundle", {}) or {}
+    scope = bundle.get("scope", "@deepseek-ai")
+    package = bundle.get("package") or f"dsh-{cfg['plugin']['name']}"
+
+    dm = dsh.get("default_model", {}) or {}
+    require(dm.get("provider") and dm.get("model"),
+            "dsh.default_model needs both `provider` and `model` "
+            "(else the base defaults the agent to a DeepSeek model)")
+
+    providers = dsh.get("providers", []) or []
+    require(providers, "dsh.providers must list at least one Mantle route")
+    for p in providers:
+        for f in ("route", "api", "baseURL", "apiKeyEnv", "model"):
+            require(p.get(f), f"dsh.providers entry missing `{f}`")
+
+    subs = dsh.get("subagents", {}) or {}
+    rev = subs.get("reviewer", {}) or {}
+    impl = subs.get("implementer", {}) or {}
+    clr = subs.get("clearance", {}) or {}
+    require(rev.get("toolName") and impl.get("toolName") and clr.get("toolName"),
+            "dsh.subagents.{reviewer,implementer,clearance} each need a `toolName`")
+    # Reviewer AND clearance are read-only by contract; their allow-set is the
+    # load-bearing control (edit/write/bash absent by omission → refused).
+    rev_allow = (rev.get("toolFilter", {}) or {}).get("allow", [])
+    clr_allow = (clr.get("toolFilter", {}) or {}).get("allow", [])
+    require(rev_allow, "dsh.subagents.reviewer.toolFilter.allow must be non-empty "
+                       "(the read-only set is the load-bearing control)")
+    require(clr_allow, "dsh.subagents.clearance.toolFilter.allow must be non-empty "
+                       "(clearance is read-only per its contract)")
+
+    base["scalars"].update({
+        "DSH_BUNDLE_NAME": f"{scope}/{package}",
+        "DSH_DEFAULT_PROVIDER": dm["provider"],
+        "DSH_DEFAULT_MODEL": dm["model"],
+        "DSH_REVIEWER_TOOLNAME": rev["toolName"],
+        "DSH_REVIEWER_MAXDEPTH": str(rev.get("maxDepth", 0)),
+        "DSH_REVIEWER_ALLOW": ", ".join(str(a) for a in rev_allow),
+        "DSH_REVIEWER_PERSONA": rev.get("persona", ""),
+        "DSH_IMPLEMENTER_TOOLNAME": impl["toolName"],
+        "DSH_IMPLEMENTER_MAXDEPTH": str(impl.get("maxDepth", 0)),
+        "DSH_IMPLEMENTER_PERSONA": impl.get("persona", ""),
+        "DSH_CLEARANCE_TOOLNAME": clr["toolName"],
+        "DSH_CLEARANCE_MAXDEPTH": str(clr.get("maxDepth", 0)),
+        "DSH_CLEARANCE_ALLOW": ", ".join(str(a) for a in clr_allow),
+        "DSH_CLEARANCE_PERSONA": clr.get("persona", ""),
+    })
+    base["arrays"]["DSH_PROVIDERS"] = [
+        {"route": p["route"], "api": p["api"], "baseURL": p["baseURL"],
+         "apiKeyEnv": p["apiKeyEnv"], "model": p["model"]}
+        for p in providers
+    ]
+    # Flip the host target: DSH emit gets the direct-tool dispatch prose, the
+    # Workflow/pipeline prose is dropped (build_bindings defaulted the other way).
+    base["conditionals"].update({"TARGET_CC": False, "TARGET_DSH": True})
+    return base
+
+
+def emit_claude_code(cfg: dict, out: Path) -> None:
+    """Render the org-owned Claude Code plugin (the original emit target)."""
     bindings = build_bindings(cfg)
-    out = Path(args.out)
     rendered = render_tree(
-        bindings,
-        FORGE_ROOT / "templates/org-plugin",
-        out,
-        FORGE_ROOT,
+        bindings, FORGE_ROOT / "templates/org-plugin", out, FORGE_ROOT,
         leak_check=True,
     )
 
@@ -191,8 +263,58 @@ def main(argv=None):
             renames += 1
 
     print(f"OK emitted {cfg['plugin']['name']} v{cfg['plugin']['version']} "
-          f"→ {args.out} ({len(rendered)} files, {renames} verb renames)")
+          f"→ {out} ({len(rendered)} files, {renames} verb renames)")
     print("leak gate: clean (no generator identity in output)")
+
+
+def emit_dsh(cfg: dict, out: Path) -> None:
+    """Render the DSH profile bundle: the bundle patch + package.json, then the
+    SHARED org-plugin skills folded in via a second (clean=False) render pass so
+    the skill templates are reused, not copied. No agent files, so no gate rename."""
+    bindings = build_bindings_dsh(cfg)
+
+    # Pass 1: the host shell — cordis.patch.yml + package.json (clean wipe of out).
+    rendered = render_tree(
+        bindings, FORGE_ROOT / "templates/dsh-harness", out, FORGE_ROOT,
+        leak_check=True,
+    )
+
+    # Pass 2..N: the shared skills. DSH has no agent files; verb-naming is applied
+    # by choosing the output directory, so no post-hoc rename is needed. One
+    # render_tree per skill into skills/<verb>/, clean=False to keep pass-1 output.
+    verbs = resolve_verbs(cfg)
+    skills = cfg["dsh"].get("skills", []) or []
+    for canon in skills:
+        require(canon in CANONICAL_VERBS, f"dsh.skills: unknown skill {canon!r}")
+        src = FORGE_ROOT / "templates/org-plugin/skills" / canon
+        require(src.is_dir(), f"dsh.skills: no template for {canon!r} at {src}")
+        rendered += render_tree(
+            bindings, src, out / "skills" / verbs[canon], FORGE_ROOT,
+            leak_check=True, clean=False,
+        )
+
+    print(f"OK emitted {bindings['scalars']['DSH_BUNDLE_NAME']} "
+          f"v{cfg['plugin']['version']} → {out} "
+          f"({len(rendered)} files, {len(skills)} skill(s))")
+    print("leak gate: clean (no generator identity in output)")
+
+
+TARGETS = {
+    "claude-code": emit_claude_code,
+    "dsh": emit_dsh,
+}
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="forge emit driver")
+    ap.add_argument("--config", default=".forge.org.yaml")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--target", choices=sorted(TARGETS), default="claude-code",
+                    help="host shell to render (default: claude-code)")
+    args = ap.parse_args(argv)
+
+    cfg = yaml.safe_load(Path(args.config).read_text())
+    TARGETS[args.target](cfg, Path(args.out))
 
 
 if __name__ == "__main__":

--- a/lib/emit.py
+++ b/lib/emit.py
@@ -185,11 +185,27 @@ def build_bindings_dsh(cfg: dict) -> dict:
             "dsh.default_model needs both `provider` and `model` "
             "(else the base defaults the agent to a DeepSeek model)")
 
+    # Auth mode for every route. `sigv4` (default) signs each request with AWS
+    # credentials from the harness's ambient chain — no token to mint, store, or
+    # leak. `bearer` keeps the apiKeyEnv reference path for a gateway fronted by
+    # a static token.
+    auth = dsh.get("auth", "sigv4")
+    require(auth in ("sigv4", "bearer"),
+            f"dsh.auth must be 'sigv4' or 'bearer' (got {auth!r})")
+
     providers = dsh.get("providers", []) or []
     require(providers, "dsh.providers must list at least one Mantle route")
     for p in providers:
-        for f in ("route", "api", "baseURL", "apiKeyEnv", "model"):
+        for f in ("route", "api", "baseURL", "model"):
             require(p.get(f), f"dsh.providers entry missing `{f}`")
+        if auth == "bearer":
+            require(p.get("apiKeyEnv"),
+                    "dsh.providers entry missing `apiKeyEnv` "
+                    "(required when dsh.auth is 'bearer')")
+        else:
+            require(p.get("region"),
+                    "dsh.providers entry missing `region` "
+                    "(required when dsh.auth is 'sigv4')")
 
     subs = dsh.get("subagents", {}) or {}
     rev = subs.get("reviewer", {}) or {}
@@ -222,14 +238,38 @@ def build_bindings_dsh(cfg: dict) -> dict:
         "DSH_CLEARANCE_ALLOW": ", ".join(str(a) for a in clr_allow),
         "DSH_CLEARANCE_PERSONA": clr.get("persona", ""),
     })
-    base["arrays"]["DSH_PROVIDERS"] = [
-        {"route": p["route"], "api": p["api"], "baseURL": p["baseURL"],
-         "apiKeyEnv": p["apiKeyEnv"], "model": p["model"]}
-        for p in providers
-    ]
+    def provider_entry(p):
+        entry = {"route": p["route"], "api": p["api"],
+                 "baseURL": p["baseURL"], "model": p["model"]}
+        if auth == "bearer":
+            entry["apiKeyEnv"] = p["apiKeyEnv"]
+        else:
+            # `service` is the SigV4 signing service; Bedrock Mantle's is
+            # `bedrock-mantle`, which a route may override for another gateway.
+            entry["service"] = p.get("service", "bedrock-mantle")
+            entry["region"] = p["region"]
+        return entry
+
+    base["arrays"]["DSH_PROVIDERS"] = [provider_entry(p) for p in providers]
+    # Under sigv4 the emit mounts the standalone `llm-mantle` adapter, whose
+    # mantle-claude/mantle-gpt routes and endpoints are fixed in the adapter —
+    # region is the one knob. Collapse the per-row regions to the single value
+    # that adapter takes, refusing a mixed set rather than silently picking one.
+    if auth == "sigv4":
+        regions = {p["region"] for p in providers}
+        require(len(regions) == 1,
+                "dsh.providers must share one region under sigv4 auth "
+                "(llm-mantle mounts one region for its fixed mantle-claude/mantle-gpt routes)")
+        base["scalars"]["DSH_MANTLE_REGION"] = next(iter(regions))
     # Flip the host target: DSH emit gets the direct-tool dispatch prose, the
     # Workflow/pipeline prose is dropped (build_bindings defaulted the other way).
-    base["conditionals"].update({"TARGET_CC": False, "TARGET_DSH": True})
+    # DSH_AUTH_* selects the per-route auth block; auth is one mode for all
+    # routes, so a global conditional over the repeated provider body is exact.
+    base["conditionals"].update({
+        "TARGET_CC": False, "TARGET_DSH": True,
+        "DSH_AUTH_SIGV4": auth == "sigv4",
+        "DSH_AUTH_BEARER": auth == "bearer",
+    })
     return base
 
 

--- a/lib/render.py
+++ b/lib/render.py
@@ -100,13 +100,20 @@ def _render_scalars(text: str, scalars: dict) -> str:
 
 
 def render_tree(bindings: dict, templates_dir: Path, out_dir: Path,
-                forge_root: Path, leak_check: bool = False) -> list[Path]:
-    """Render every *.template under templates_dir into out_dir. Returns paths."""
+                forge_root: Path, leak_check: bool = False,
+                clean: bool = True) -> list[Path]:
+    """Render every *.template under templates_dir into out_dir. Returns paths.
+
+    clean=True (default) wipes out_dir first — the original single-pass
+    behaviour. Pass clean=False for a second render pass into an already-
+    populated tree (e.g. folding the shared skills into a bundle) so the first
+    pass's output is not clobbered.
+    """
     scalars = resolve_snippets(bindings, forge_root)
     arrays = bindings.get("arrays", {})
     conditionals = bindings.get("conditionals", {})
 
-    if out_dir.exists():
+    if clean and out_dir.exists():
         shutil.rmtree(out_dir)
     rendered = []
     for tpl in sorted(templates_dir.rglob("*.template")):

--- a/templates/dsh-harness/cordis.patch.yml.template
+++ b/templates/dsh-harness/cordis.patch.yml.template
@@ -28,9 +28,14 @@
 # and mantle-gpt (openai-responses) routes, endpoints, and model ids are fixed
 # in the adapter and every request is signed from the ambient AWS chain, so the
 # only knob is the region — no route rows, no token to mint or store.
-- id: llm-mantle
-  config:
-    region: {{DSH_MANTLE_REGION}}
+# INSERT, not a config-override: llm-mantle is NOT in dsh-base (base mounts
+# llm-pi-ai/llm-deepseek), so a bare `- id: llm-mantle` override finds no entry
+# and fails to compose. Mount it by package name; region is the one config knob.
+- insert:
+    - id: llm-mantle
+      name: '@deepseek-ai/dsh-llm-mantle'
+      config:
+        region: {{DSH_MANTLE_REGION}}
 {{/DSH_AUTH_SIGV4}}
 {{#DSH_AUTH_BEARER}}
 # The pi-ai multi-provider adapter under bearer auth: each route names its wire

--- a/templates/dsh-harness/cordis.patch.yml.template
+++ b/templates/dsh-harness/cordis.patch.yml.template
@@ -7,8 +7,10 @@
 #   3. reuses the base skill-filesystem provider to discover the {{PLUGIN_NAME}}
 #      skills shipped in this bundle's skills/ directory.
 #
-# Credentials are NEVER inlined: each route carries an apiKeyEnv *reference* the
-# adapter resolves per request.
+# Credentials are NEVER inlined. Under SigV4 auth (the default) each route signs
+# every request with AWS credentials from the harness's ambient chain — nothing
+# to mint or store. Under bearer auth each route carries an apiKeyEnv *reference*
+# the adapter resolves per request.
 #
 # Skill discovery: the base's skill-filesystem reads $DSH_BUNDLED_SKILL_DIR as a
 # default bundled root. Point it at this bundle's skills/ directory at launch —
@@ -21,8 +23,19 @@
     provider: {{DSH_DEFAULT_PROVIDER}}
     model: {{DSH_DEFAULT_MODEL}}
 
-# The pi-ai multi-provider adapter, given its routes here (the composition base
-# for the llm-pi-ai settings section). Both Mantle wire shapes, config-only.
+{{#DSH_AUTH_SIGV4}}
+# The standalone SigV4 Mantle adapter. Its mantle-claude (anthropic-messages)
+# and mantle-gpt (openai-responses) routes, endpoints, and model ids are fixed
+# in the adapter and every request is signed from the ambient AWS chain, so the
+# only knob is the region — no route rows, no token to mint or store.
+- id: llm-mantle
+  config:
+    region: {{DSH_MANTLE_REGION}}
+{{/DSH_AUTH_SIGV4}}
+{{#DSH_AUTH_BEARER}}
+# The pi-ai multi-provider adapter under bearer auth: each route names its wire
+# shape, base URL, and an apiKeyEnv *reference* the adapter resolves per request
+# (never the token itself). Both Mantle wire shapes, config-only.
 - id: llm-pi-ai
   config:
     providers:
@@ -34,6 +47,7 @@
         models:
           - id: {{model}}
 {{/DSH_PROVIDERS}}
+{{/DSH_AUTH_BEARER}}
 
 # Two named subagent delegation tools over the in-process spawn provider.
 - insert:

--- a/templates/dsh-harness/cordis.patch.yml.template
+++ b/templates/dsh-harness/cordis.patch.yml.template
@@ -1,0 +1,77 @@
+# {{PLUGIN_NAME}} — DeepSeek Harness profile bundle.
+#
+# A profile-bundle patch applied over @deepseek-ai/dsh-base (last write wins per
+# row). It does three things and nothing more:
+#   1. routes the transport-default agent model to a Mantle (Bedrock) provider,
+#   2. mounts a read-only reviewer and a full-tool implementer subagent tool,
+#   3. reuses the base skill-filesystem provider to discover the {{PLUGIN_NAME}}
+#      skills shipped in this bundle's skills/ directory.
+#
+# Credentials are NEVER inlined: each route carries an apiKeyEnv *reference* the
+# adapter resolves per request.
+#
+# Skill discovery: the base's skill-filesystem reads $DSH_BUNDLED_SKILL_DIR as a
+# default bundled root. Point it at this bundle's skills/ directory at launch —
+# no row here, so the bundle stays path-agnostic and can't fail load when unset.
+
+# Route the transport-default model to the Mantle Claude route; otherwise the
+# base defaults every entry-point Agent to a DeepSeek model.
+- id: agent-default-model
+  config:
+    provider: {{DSH_DEFAULT_PROVIDER}}
+    model: {{DSH_DEFAULT_MODEL}}
+
+# The pi-ai multi-provider adapter, given its routes here (the composition base
+# for the llm-pi-ai settings section). Both Mantle wire shapes, config-only.
+- id: llm-pi-ai
+  config:
+    providers:
+{{#DSH_PROVIDERS}}
+      {{route}}:
+        api: {{api}}
+        baseURL: {{baseURL}}
+        apiKeyEnv: {{apiKeyEnv}}
+        models:
+          - id: {{model}}
+{{/DSH_PROVIDERS}}
+
+# Two named subagent delegation tools over the in-process spawn provider.
+- insert:
+    # Read-only reviewer. toolFilter.allow restricts the child's assembled tool
+    # catalog to exactly these tools; edit/write/bash are absent by omission and
+    # refuse to execute (restrict() fails loud on any name that is not a DSH tool).
+    - id: tool-subagent-review
+      name: '@deepseek-ai/dsh-tool-subagent'
+      config:
+        provider: spawn
+        toolName: {{DSH_REVIEWER_TOOLNAME}}
+        backgroundMode: one-shot
+        maxDepth: {{DSH_REVIEWER_MAXDEPTH}}
+        toolFilter: { allow: [{{DSH_REVIEWER_ALLOW}}] }
+        persona: "{{DSH_REVIEWER_PERSONA}}"
+
+    # Implementer: the same tool with NO toolFilter — the child inherits the
+    # full tool set (read/grep/glob + edit/write/bash).
+    - id: tool-subagent-implement
+      name: '@deepseek-ai/dsh-tool-subagent'
+      config:
+        provider: spawn
+        toolName: {{DSH_IMPLEMENTER_TOOLNAME}}
+        backgroundMode: one-shot
+        maxDepth: {{DSH_IMPLEMENTER_MAXDEPTH}}
+        persona: "{{DSH_IMPLEMENTER_PERSONA}}"
+
+    # Clearance: the gate validator. Read-only by CONTRACT (validates tickets/PRs
+    # against the wiki's gate rules, never writes) — so it carries the same
+    # toolFilter.allow as the reviewer; edit/write/bash are absent by omission
+    # and refuse. So the three rows are: implement=full, review=read-only,
+    # clearance=read-only.
+    - id: tool-subagent-clearance
+      name: '@deepseek-ai/dsh-tool-subagent'
+      config:
+        provider: spawn
+        toolName: {{DSH_CLEARANCE_TOOLNAME}}
+        backgroundMode: one-shot
+        maxDepth: {{DSH_CLEARANCE_MAXDEPTH}}
+        toolFilter: { allow: [{{DSH_CLEARANCE_ALLOW}}] }
+        persona: "{{DSH_CLEARANCE_PERSONA}}"

--- a/templates/dsh-harness/package.json.template
+++ b/templates/dsh-harness/package.json.template
@@ -1,0 +1,13 @@
+{
+  "name": "{{DSH_BUNDLE_NAME}}",
+  "version": "{{PLUGIN_VERSION}}",
+  "description": "{{PLUGIN_DESCRIPTION}}",
+  "private": true,
+  "type": "module",
+  "license": "{{PLUGIN_LICENSE}}",
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    }
+  }
+}

--- a/templates/org-plugin/skills/execute/SKILL.md.template
+++ b/templates/org-plugin/skills/execute/SKILL.md.template
@@ -79,26 +79,27 @@ context to execute, constitution constraints are specified, and feature-flag
 alignment across producer/consumer tasks is clear. Iterate with the engineer until
 the gate passes.
 
-### 5. Dispatch agents as a Workflow (scoped, isolated context)
+### 5. Dispatch agents (scoped, isolated context)
 
+**The invariant (host-independent).** For each ready task, dispatch an **implementer**
+with a context envelope containing **only**: the task spec, the target repo + branch,
+test expectations, the applicable constitution rules, and feature-flag instructions. Do
+**not** pre-load sibling-task context — isolation is what keeps agents honest and cheap.
+When the implementer opens its PR, dispatch a **reviewer** in a *separate context* that
+sees only the diff + task spec — never the implementer's reasoning. The reviewer is
+**read-only** by construction. **No-self-review is structural:** two different subagents
+in two different contexts, never one agent reviewing itself. This boundary is not
+optional and is independent of any platform backstops the wiki declares. Only the
+*dispatch mechanism* below differs by host — the split and the read-only reviewer do not.
+
+{{#TARGET_CC}}
 Run the wave as a **Workflow** (Claude Code's `Workflow` tool) — the orchestrator's
 mechanism for spawning ephemeral subagents deterministically. One agent = one subagent
-inside the workflow. Pipeline the tasks so each flows implement → review independently
-(see the pattern below); the orchestrator session holds only the plan, never the agents'
-internals.
-
-For each ready task, dispatch an **implementer** agent (the `implementer` subagent — see
-`agents/implementer.md`) with a context envelope containing **only**: the task spec,
-the target repo + branch, test expectations, the applicable constitution rules, and
-feature-flag instructions. Do **not** pre-load sibling-task context — isolation is what
-keeps agents honest and cheap.
-
-When an implementer opens its PR, dispatch a **reviewer** agent (the `reviewer`
-subagent — see `agents/reviewer.md`) as a **separate workflow stage / distinct
-subagent** that sees only the diff + task spec — never the implementer's reasoning.
-**No-self-review is structural here:** it is two different subagents in two different
-contexts, not one agent reviewing itself. This boundary is not optional and is
-independent of any platform backstops the wiki declares.
+inside the workflow. Pipeline the tasks so each flows implement → review independently:
+dispatch the **implementer** subagent (see `agents/implementer.md`) with the envelope
+above, then on its PR dispatch the **reviewer** subagent (see `agents/reviewer.md`) as a
+**separate workflow stage / distinct subagent**. A single agent that implements then
+reviews its own diff in one context is the forbidden anti-pattern.
 
 ```
 // one task → implement, then review, as independent pipeline stages:
@@ -106,11 +107,6 @@ pipeline(tasks,
   t => agent(implementerEnvelope(t),  { agentType: 'implementer', isolation: 'worktree' }),
   pr => agent(reviewEnvelope(pr),     { agentType: 'reviewer' }))   // separate context = no self-review
 ```
-
-The principle is fixed (a Workflow of context-isolated subagents); the exact harness
-the org runs may differ — but if it isn't the Workflow tool, it MUST still preserve the
-implement/review context split. A single agent that implements then reviews its own
-diff in one context is the forbidden anti-pattern.
 
 **Worktree isolation in a multi-repo workspace.** When a session runs from a
 *workspace root* (whose subdirectories are the real git repos, the root itself not a
@@ -132,6 +128,27 @@ land on a banned model. **Model floor for this org:** default **{{MODEL_POLICY_D
 banned: **{{MODEL_POLICY_BANNED}}**. {{MODEL_POLICY_RULE}} If a stage genuinely needs a
 one-off (non-archetype) agent, it MUST set `model` explicitly — never leave it implicit.
 We optimize for value-per-token, not cheapest token.
+{{/TARGET_CC}}
+{{#TARGET_DSH}}
+There is **no workflow-orchestration tool** on this host, and the `agent()` delegation
+path structurally **drops the child's `toolFilter`** — a reviewer spawned that way would
+not be read-only. Dispatch instead by calling the **direct delegation tools** by name
+from the orchestrator loop:
+
+1. For each ready task, call **`subagent_implement`** (full tool set) with the envelope
+   above. It writes the code and opens the PR in its own context.
+2. On that PR, call **`subagent_review`** (read-only — its `toolFilter` allows only
+   `read`/`grep`/`glob`, so any edit/write/bash attempt refuses). It sees only the diff
+   + task spec, never the implementer's reasoning.
+3. At the gate points, call **`subagent_clearance`** (also read-only) to validate.
+
+`subagent_review` is the **only** dispatch path on this host where the reviewer's
+`toolFilter` reaches the child, so route review through it — never through a workflow
+stage. Consume **only** the structured verdict each tool returns; never pull the child's
+transcript. Each subagent runs on the Mantle model pinned by the bundle's subagent rows,
+and the org model floor still holds (default **{{MODEL_POLICY_DEFAULT}}**; banned:
+**{{MODEL_POLICY_BANNED}}**). {{MODEL_POLICY_RULE}}
+{{/TARGET_DSH}}
 
 **Context economy — keep the orchestrator lean.** You are the one long-lived context;
 every token a stage pours into it is permanent. So make each stage **return only

--- a/tests/test_dsh_emit.py
+++ b/tests/test_dsh_emit.py
@@ -45,9 +45,12 @@ def test_dsh_bindings_reuse_org_bindings_and_flip_target():
     # Every org scalar from the CC target survives unchanged in the DSH bindings.
     for k, v in cc["scalars"].items():
         assert dsh["scalars"][k] == v, f"DSH bindings dropped/changed org scalar {k}"
-    # Host target flipped.
+    # Host target flipped, plus the sigv4 auth conditionals (fixture default).
     assert cc["conditionals"] == {"TARGET_CC": True, "TARGET_DSH": False}
-    assert dsh["conditionals"] == {"TARGET_CC": False, "TARGET_DSH": True}
+    assert dsh["conditionals"] == {
+        "TARGET_CC": False, "TARGET_DSH": True,
+        "DSH_AUTH_SIGV4": True, "DSH_AUTH_BEARER": False,
+    }
 
 
 def test_dsh_emit_is_leak_clean_and_fully_resolved(tmp_path):
@@ -113,6 +116,80 @@ def test_dsh_missing_section_fails_loud():
     """A config with no dsh: section cannot emit the DSH target."""
     cfg = _cfg()
     cfg.pop("dsh")
+    with pytest.raises(SystemExit):
+        emit.build_bindings_dsh(cfg)
+
+
+def test_dsh_sigv4_mounts_llm_mantle_not_llm_pi_ai(tmp_path):
+    """The fixture uses auth: sigv4, so the rendered patch mounts the standalone
+    llm-mantle adapter (fixed routes signed from the ambient AWS chain) with only
+    a region — no llm-pi-ai providers block, no apiKeyEnv, no minted token, and
+    no route-level sigv4 block (the adapter owns signing)."""
+    out = tmp_path / "bundle"
+    emit.emit_dsh(_cfg(), out)
+    patch = (out / "cordis.patch.yml").read_text()
+    assert "- id: llm-mantle" in patch
+    assert "region: us-east-1" in patch
+    assert "- id: llm-pi-ai" not in patch
+    assert "sigv4:" not in patch
+    assert "apiKeyEnv:" not in patch
+    assert "GW_TOKEN" not in patch and "MANTLE_TOKEN" not in patch
+
+
+def test_dsh_bearer_mounts_llm_pi_ai_with_apikeyenv(tmp_path):
+    """auth: bearer keeps the llm-pi-ai fallback path — each route carries its
+    apiKeyEnv reference and no llm-mantle mount."""
+    cfg = _cfg()
+    cfg["dsh"]["auth"] = "bearer"
+    for p in cfg["dsh"]["providers"]:
+        p["apiKeyEnv"] = "GW_TOKEN"
+    out = tmp_path / "bundle"
+    emit.emit_dsh(cfg, out)
+    patch = (out / "cordis.patch.yml").read_text()
+    assert "- id: llm-pi-ai" in patch
+    assert "apiKeyEnv: GW_TOKEN" in patch
+    assert "- id: llm-mantle" not in patch
+    assert "sigv4:" not in patch
+
+
+def test_dsh_sigv4_requires_one_region(tmp_path):
+    """MUTATION: sigv4 routes that disagree on region must fail the emit loud —
+    llm-mantle mounts exactly one region for its fixed routes."""
+    cfg = _cfg()
+    cfg["dsh"]["auth"] = "sigv4"
+    cfg["dsh"]["providers"][0]["region"] = "us-east-1"
+    second = dict(cfg["dsh"]["providers"][0])
+    second["route"] = "gw-gpt"
+    second["region"] = "eu-west-2"
+    cfg["dsh"]["providers"].append(second)
+    with pytest.raises(SystemExit):
+        emit.build_bindings_dsh(cfg)
+
+
+def test_dsh_sigv4_requires_region():
+    """MUTATION: a sigv4 route with no region must fail the emit loud."""
+    cfg = _cfg()
+    cfg["dsh"]["auth"] = "sigv4"
+    for p in cfg["dsh"]["providers"]:
+        p.pop("region", None)
+    with pytest.raises(SystemExit):
+        emit.build_bindings_dsh(cfg)
+
+
+def test_dsh_bearer_requires_apikeyenv():
+    """MUTATION: a bearer route with no apiKeyEnv must fail the emit loud."""
+    cfg = _cfg()
+    cfg["dsh"]["auth"] = "bearer"
+    for p in cfg["dsh"]["providers"]:
+        p.pop("apiKeyEnv", None)
+    with pytest.raises(SystemExit):
+        emit.build_bindings_dsh(cfg)
+
+
+def test_dsh_unknown_auth_fails_loud():
+    """An auth mode other than sigv4/bearer is refused."""
+    cfg = _cfg()
+    cfg["dsh"]["auth"] = "oauth"
     with pytest.raises(SystemExit):
         emit.build_bindings_dsh(cfg)
 

--- a/tests/test_dsh_emit.py
+++ b/tests/test_dsh_emit.py
@@ -128,6 +128,11 @@ def test_dsh_sigv4_mounts_llm_mantle_not_llm_pi_ai(tmp_path):
     out = tmp_path / "bundle"
     emit.emit_dsh(_cfg(), out)
     patch = (out / "cordis.patch.yml").read_text()
+    # A MOUNT, not a config-override. llm-mantle is NOT in dsh-base (base mounts
+    # llm-pi-ai/llm-deepseek), so a bare top-level `- id: llm-mantle` override
+    # finds no entry to patch and fails to compose ("entry not found"). It must
+    # be inserted with its package name, which a config-override never carries.
+    assert "name: '@deepseek-ai/dsh-llm-mantle'" in patch
     assert "- id: llm-mantle" in patch
     assert "region: us-east-1" in patch
     assert "- id: llm-pi-ai" not in patch

--- a/tests/test_dsh_emit.py
+++ b/tests/test_dsh_emit.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Anti-regression net for the DSH (DeepSeek Harness) emit target.
+
+`/forge:emit --target dsh` renders a DeepSeek Harness profile bundle from the
+SAME .forge.org.yaml as the Claude Code target — one source, two emits. This
+test locks the two load-bearing invariants of that second target:
+
+  1. LEAK GATE: the emitted bundle carries ZERO generator identity (render_tree
+     raises SystemExit(3) otherwise) and no unresolved {{placeholders}} (exit 2).
+  2. READ-ONLY CONTROL: the reviewer and clearance subagent rows each carry a
+     non-empty toolFilter.allow (edit/write/bash absent by omission → refused);
+     the implementer row carries NO filter (full tool set). This is the control
+     the whole no-self-review split rests on, so removing it must FAIL loud.
+
+It also asserts build_bindings_dsh reuses build_bindings (one source of org
+bindings) and flips the host target (TARGET_CC off, TARGET_DSH on).
+
+Run:  uv run --with pytest --with pyyaml pytest tests/test_dsh_emit.py -q
+"""
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+LIB = Path(__file__).resolve().parent.parent / "lib"
+sys.path.insert(0, str(LIB))
+import emit  # noqa: E402
+import render  # noqa: E402
+
+FORGE_ROOT = Path(__file__).resolve().parent.parent
+FIXTURE = FORGE_ROOT / "adapters/tracker/_test/sample.forge.org.yaml"
+
+
+def _cfg():
+    return yaml.safe_load(FIXTURE.read_text())
+
+
+def test_dsh_bindings_reuse_org_bindings_and_flip_target():
+    """build_bindings_dsh reuses build_bindings wholesale (one source) and flips
+    the host conditionals so the DSH dispatch prose renders, not the CC prose."""
+    cfg = _cfg()
+    cc = emit.build_bindings(cfg)
+    dsh = emit.build_bindings_dsh(cfg)
+    # Every org scalar from the CC target survives unchanged in the DSH bindings.
+    for k, v in cc["scalars"].items():
+        assert dsh["scalars"][k] == v, f"DSH bindings dropped/changed org scalar {k}"
+    # Host target flipped.
+    assert cc["conditionals"] == {"TARGET_CC": True, "TARGET_DSH": False}
+    assert dsh["conditionals"] == {"TARGET_CC": False, "TARGET_DSH": True}
+
+
+def test_dsh_emit_is_leak_clean_and_fully_resolved(tmp_path):
+    """emit_dsh renders with leak_check=True: reaching the asserts means no
+    generator identity (exit 3) and no unresolved placeholder (exit 2) tripped."""
+    out = tmp_path / "bundle"
+    emit.emit_dsh(_cfg(), out)
+
+    # The host shell + the folded shared skills are present.
+    assert (out / "cordis.patch.yml").is_file()
+    assert (out / "package.json").is_file()
+    assert (out / "skills" / "execute" / "SKILL.md").is_file()  # fixture: no verb rename
+
+    # Belt-and-suspenders leak scan over the whole emitted tree.
+    for f in out.rglob("*"):
+        if f.is_file():
+            for i, line in enumerate(f.read_text().splitlines(), 1):
+                assert not render.LEAK_RE.search(line), (
+                    f"generator identity leaked into {f.relative_to(out)}:{i}: {line!r}"
+                )
+
+
+def test_dsh_reviewer_and_clearance_are_read_only_implementer_is_not(tmp_path):
+    """LOAD-BEARING: in the rendered patch, reviewer + clearance carry a
+    read-only toolFilter; the implementer carries none (full tools)."""
+    out = tmp_path / "bundle"
+    emit.emit_dsh(_cfg(), out)
+    patch = (out / "cordis.patch.yml").read_text()
+
+    assert "toolName: subagent_review" in patch
+    assert "toolName: subagent_clearance" in patch
+    assert "toolName: subagent_implement" in patch
+    # Exactly two read-only filters (reviewer + clearance); the implementer row
+    # must NOT introduce a third. Count is the guard against a mis-wired filter.
+    assert patch.count("toolFilter:") == 2, (
+        "expected exactly 2 toolFilter rows (reviewer + clearance); the "
+        "implementer must have none"
+    )
+    assert "allow: [read, grep, glob]" in patch
+
+
+def test_dsh_engage_skill_uses_direct_dispatch_not_workflow(tmp_path):
+    """The DSH-target engage skill renders the direct-tool dispatch (TARGET_DSH)
+    and drops the Claude Code Workflow/pipeline prose (TARGET_CC)."""
+    out = tmp_path / "bundle"
+    emit.emit_dsh(_cfg(), out)
+    engage = (out / "skills" / "execute" / "SKILL.md").read_text()
+    assert "subagent_implement" in engage and "subagent_review" in engage
+    # The CC-only Workflow pipeline example must not survive into the DSH emit.
+    assert "pipeline(tasks," not in engage
+
+
+def test_dsh_empty_reviewer_allow_fails_loud():
+    """MUTATION: emptying the reviewer's read-only allow-set must FAIL the emit
+    (the read-only set is the load-bearing control, not a vacuous default)."""
+    cfg = _cfg()
+    cfg["dsh"]["subagents"]["reviewer"]["toolFilter"] = {"allow": []}
+    with pytest.raises(SystemExit):
+        emit.build_bindings_dsh(cfg)
+
+
+def test_dsh_missing_section_fails_loud():
+    """A config with no dsh: section cannot emit the DSH target."""
+    cfg = _cfg()
+    cfg.pop("dsh")
+    with pytest.raises(SystemExit):
+        emit.build_bindings_dsh(cfg)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Adds `forge emit --target {claude-code,dsh}`: one `.forge.org.yaml`, two emits.
`--target dsh` renders a DeepSeek Harness profile bundle (`cordis.patch.yml` +
`package.json`) with the shared operating-model skills folded in via a second
(`clean=False`) render pass — only the host shell differs.

## What
- `build_bindings_dsh` reuses `build_bindings` wholesale (one source of org
  bindings), then layers DSH host-shell keys and flips `TARGET_CC`→`TARGET_DSH`.
- §5 of the shared engage/execute skill hoists the host-independent invariant
  (implement/review split, read-only reviewer, no-self-review) into shared prose;
  `{{#TARGET_CC}}` keeps the Workflow/pipeline mechanics, `{{#TARGET_DSH}}` uses the
  direct `subagent_implement`→`subagent_review`→`subagent_clearance` loop.
  **CC prose is semantically unchanged (restructured, not rewritten — not byte-identical.)**
- Config lives in `.forge.org.example.yaml` (neutral `acme`/example values,
  `MANTLE_TOKEN` env-name only). No real org config is committed.
- Leak gate: DSH output carries zero generator identity (verified).
- Read-only control locked: reviewer + clearance carry `[read,grep,glob]`;
  implementer none. `commands/emit.md` documents `--target`.

## Tests
`tests/test_dsh_emit.py` — bindings reuse, leak-clean + resolved, read-only
reviewer/clearance vs full implementer, DSH direct-dispatch (no Workflow prose),
plus mutation guards (empty reviewer allow-set / missing `dsh:` fail loud). **20 passed.**

## Follow-ups (out of scope)
- `plugin.json` minor bump for the new capability (release-owner call).
- Pre-existing latent bug on `main`: `build_bindings` always builds
  `TRACKER_COMMENT_LIST_SNIPPET` but `adapters/tracker/jira-mcp.md` lacks that
  label — any `jira-mcp` config fails emit for both targets. Separate ticket.