### PR TITLE
feat(emit): add --target opencode (Hyperdrive as an opencode config)

### DIFF
--- a/.forge.org.example.yaml
+++ b/.forge.org.example.yaml
@@ -129,6 +129,54 @@ operating_model:
     - branch-protection
     - required-reviews
 
+# --- opencode target (only read by `emit --target opencode`). ---
+# EVERYTHING ABOVE IS SHARED — one org config, N hosts. This block adds ONLY what the
+# opencode host needs that Claude Code doesn't: how to reach the model provider, and the
+# host-native names for the same three roles declared in `agents:` above. The verbs, the
+# wiki pointers, the model policy and the role contracts are NOT restated here.
+opencode:
+  provider:
+    id: amazon-bedrock                    # the ONLY provider — emitted as an "enabled_providers"
+                                          # ALLOWLIST, which holds even when the machine has an
+                                          # ambient ANTHROPIC_API_KEY/OPENAI_API_KEY
+    profile: acme-ai                      # an AWS *profile name* — auth comes from the ambient SSO
+    region: us-east-1                     # chain (`aws sso login --profile <name>`). NEVER a key.
+    models:                               # CRIS ids to declare (models.dev doesn't know them)
+      - us.anthropic.claude-sonnet-4-5-20250929-v1:0
+      - us.openai.gpt-5-2025-08-07
+  model:
+    provider: amazon-bedrock
+    model: us.anthropic.claude-sonnet-4-5-20250929-v1:0
+  primary_agent: build                    # the long-lived orchestrator the verbs run as
+  disabled_providers: ["opencode"]         # belt-and-suspenders: names the built-in provider too.
+                                          # The allowlist above is the load-bearing control.
+  # The three roles, host-native. Each `agent:` name is BOTH the token the skills dispatch
+  # via `task` AND the emitted `agent/<name>.md` filename — one source, so a dispatch can
+  # never miss and fall back to the full-permission primary agent. Names must be distinct.
+  # `toolFilter.allow` is the READ-ONLY contract for the two validating roles: it must be
+  # non-empty and must never contain edit/write/patch/bash/task (emit fails closed if it
+  # does — a reviewer that can spawn a writer is not read-only). The emitted permission
+  # deny block is DERIVED from it: deny = [edit, bash, task, webfetch, websearch] - allow,
+  # so widening an allow-list here really does widen the agent.
+  # The implementer deliberately declares NO toolFilter: it needs full tools.
+  subagents:
+    implementer:
+      agent: implementer
+      persona: "Ships the smallest honest change, test first."
+    reviewer:
+      agent: reviewer
+      toolFilter:
+        allow: [read, grep, glob]
+      persona: "Judges the diff, never the author."
+    clearance:
+      agent: gate                         # the agent FILE name + dispatch token. Independent of
+                                          # the `gate` verb (which names command/ and skill/).
+      toolFilter:
+        allow: [read, grep, glob]
+      persona: "Verdict plus specific deficiencies, nothing else."
+  # Which shared skills to fold into skill/. `gate` is an agent, not a verb, so it is absent.
+  skills: [intro, setup, prime, inception, refine, execute, wiki, handoff]
+
 # --- Chat / notifications (optional, adapter-shaped). ---
 integrations:
   # - type: chat

--- a/commands/emit.md
+++ b/commands/emit.md
@@ -17,12 +17,17 @@ how *this* org works, owned entirely by the org.
 ## Invocation
 
 ```
-/forge:emit [--config <path>] [--out <dir>]
+/forge:emit [--config <path>] [--out <dir>] [--target {claude-code,opencode}]
 ```
 
 - `--config` — the org-tier config. Defaults to `./.forge.org.yaml`
   (see `.forge.org.example.yaml` for the shape).
 - `--out` — where to write the package. Defaults to `../<plugin.name>`.
+- `--target` — the host to package for. Defaults to `claude-code` (a Claude Code plugin:
+  `skills/` + `agents/` + `hooks/` + `.claude-plugin/`). `opencode` emits an opencode
+  configuration (`opencode.json` + `agent/` + `command/` + `skill/`) from the **same**
+  config and requires the `opencode:` block. The skill bodies are shared byte-for-byte
+  across targets except at the `{{#TARGET_*}}` conditionals and the host-noun scalars.
 
 ## What this command does
 

--- a/lib/emit.py
+++ b/lib/emit.py
@@ -1,14 +1,24 @@
 #!/usr/bin/env python3
-"""Driver for /forge:emit — turn a .forge.org.yaml into an org-owned plugin.
+"""Driver for /forge:emit — turn a .forge.org.yaml into an org-owned harness.
 
 Computes the org-tier bindings from the config, then calls the SHARED renderer
 (lib/render.py) with the leak gate on. This is the deterministic engine behind
 the /forge:emit command; the command doc is the human-facing procedure.
 
+ONE config, N TARGETS. The org tier is host-neutral: the same .forge.org.yaml can
+be emitted as a Claude Code plugin (`--target claude-code`, the default) or as an
+opencode configuration (`--target opencode`). The skill bodies are SHARED byte-for-byte
+between targets; only the host packaging (manifest vs opencode.json, agents/ vs agent/,
+hooks vs plugin/) and the few host-specific lines behind {{#TARGET_*}} conditionals
+differ.
+
 Usage:
-  uv run --with pyyaml python lib/emit.py --config <.forge.org.yaml> --out <dir>
+  uv run --with pyyaml python lib/emit.py --config <.forge.org.yaml> --out <dir> \
+      [--target claude-code|opencode]
 """
 import argparse
+import json
+import re
 import sys
 from pathlib import Path
 
@@ -139,9 +149,28 @@ def build_bindings(cfg: dict) -> dict:
             "AGENT_REVIEWER_EFFORT": agent_field(cfg, "reviewer", "effort", "high"),
             "AGENT_GATE_MODEL": agent_field(cfg, "gate", "model"),
             "AGENT_GATE_EFFORT": agent_field(cfg, "gate", "effort", "medium"),
+            # Role DISPATCH names — the token a shared skill must use whenever it tells
+            # the orchestrator to dispatch a role. Every host names its agent files
+            # differently, so a shared template may NEVER hardcode a role name: on
+            # claude-code the emitted files are agents/implementer.md, agents/reviewer.md
+            # and agents/<verbs['gate']>.md (rename_verbs verb-renames the gate agent), so
+            # these bind to exactly those names; the opencode layer rebinds them to
+            # subagents.<role>.agent. Bound here (not only in the opencode builder) so a
+            # shared template's dispatch prose resolves to a REAL agent file in EVERY
+            # target — a token that resolves to nothing is a fail-open (the host falls
+            # back to the full-permission primary agent).
+            "IMPLEMENTER_AGENT": "implementer",
+            "REVIEWER_AGENT": "reviewer",
+            "CLEARANCE_AGENT": verbs["gate"],
+            # Host nouns — the ONLY places a shared template names its host. The
+            # opencode bindings override these; everything else stays identical.
+            "HOST_NOUN": "a Claude Code plugin",
+            "HOST_DISPATCH_NOUN": "Workflow stages",
         },
         "arrays": {"PRIME_READS": wiki["prime_reads"]},
-        "conditionals": {},
+        # Exactly one TARGET_* is true per emit. Shared templates gate host-specific
+        # prose on these; a template with no conditional renders in every target.
+        "conditionals": {"TARGET_CC": True, "TARGET_OPENCODE": False},
         "snippets": [
             {"placeholder": p, "adapter": adapter, "label": p, "vars": snippet_vars}
             for p in ("TRACKER_PRIME_SNIPPET", "TRACKER_VIEW_ISSUE_SNIPPET",
@@ -152,15 +181,253 @@ def build_bindings(cfg: dict) -> dict:
     }
 
 
-def main(argv=None):
-    ap = argparse.ArgumentParser(description="forge emit driver")
-    ap.add_argument("--config", default=".forge.org.yaml")
-    ap.add_argument("--out", required=True)
-    args = ap.parse_args(argv)
+# --- opencode target -------------------------------------------------------------
+# The dangerous capability set: write, command execution, delegation, egress. A
+# reviewer/gate agent on opencode is made read-only by DENYING these permissions (a
+# bare-string `deny` removes the tool from the model's toolset AND refuses at exec).
+# read/grep/glob/list stay default-allow — that is what a reviewer needs.
+#
+# The emitted deny block is DERIVED, per agent, from that agent's own
+# `toolFilter.allow` in the config: deny = DANGEROUS_CAPS - allow. The config is
+# therefore load-bearing, not documentation — delete a capability from an allow-list
+# and the artifact changes; add `task` to one and the emit fails (below).
+DANGEROUS_CAPS = ["edit", "bash", "task", "webfetch", "websearch"]
+# These may NEVER appear in a read-only agent's allow-list: write/exec/delegate.
+# `task` is the load-bearing one — without it a "read-only" reviewer can spawn an
+# unrestricted implementer and launder writes.
+OC_FORBIDDEN_IN_READONLY_ALLOW = ["edit", "write", "patch", "bash", "task"]
 
-    cfg = yaml.safe_load(Path(args.config).read_text())
+
+def derived_deny(allow) -> list[str]:
+    """The deny set an agent's allow-list implies: every dangerous cap NOT allowed."""
+    allowed = {str(a).lower() for a in (allow or [])}
+    return [c for c in DANGEROUS_CAPS if c not in allowed]
+
+# Anything that smells like a secret is rejected: the Bedrock provider authenticates
+# through the ambient AWS chain (SSO profile NAME + region), never an inline credential.
+CREDENTIAL_RE = re.compile(
+    r"(?i)(secret|password|passwd|api[_-]?key|apikey|access[_-]?key|"
+    r"session[_-]?token|bearer|private[_-]?key|AKIA[0-9A-Z]{16})")
+
+
+def _no_credential(path, val):
+    require(not CREDENTIAL_RE.search(str(val)),
+            f"{path} looks like a credential ({val!r}) — the Bedrock provider takes "
+            f"NAMES only (aws profile + region), auth comes from the ambient SSO chain")
+    require(len(str(val)) <= 64, f"{path} is implausibly long for a name ({len(str(val))} chars)")
+
+
+def _model_display_name(model_id: str) -> str:
+    """A human label for a CRIS model id (models.dev does not know these)."""
+    name = str(model_id)
+    name = re.sub(r"^(us|eu|apac)\.", "", name)          # CRIS region prefix
+    name = re.sub(r"^(anthropic|openai|meta|mistral)\.", "", name)  # vendor
+    name = re.sub(r"-v\d+:\d+$", "", name)                # bedrock version suffix
+    name = re.sub(r"-(\d{8}|\d{4}-\d{2}-\d{2})$", "", name)  # snapshot date
+    return name or str(model_id)
+
+
+def build_bindings_opencode(cfg: dict) -> dict:
+    """Org bindings + the opencode-target layer. Fail-closed on every control."""
+    b = build_bindings(cfg)          # org scalars stay IDENTICAL across targets
+
+    oc = cfg.get("opencode")
+    require(isinstance(oc, dict) and oc,
+            "opencode: block is required for --target opencode")
+
+    prov = oc.get("provider") or {}
+    for key in ("id", "profile", "region"):
+        require(prov.get(key), f"opencode.provider.{key} is required")
+        _no_credential(f"opencode.provider.{key}", prov[key])
+    for stray in sorted(set(prov) - {"id", "profile", "region", "models"}):
+        _no_credential(f"opencode.provider.{stray}", stray)
+        _no_credential(f"opencode.provider.{stray}", prov[stray])
+
+    model = oc.get("model") or {}
+    require(model.get("model"), "opencode.model.model is required")
+    model_provider = model.get("provider") or prov["id"]
+
+    subs = oc.get("subagents") or {}
+    for role in ("implementer", "reviewer", "clearance"):
+        require(isinstance(subs.get(role), dict) and subs[role],
+                f"opencode.subagents.{role} is required")
+        require(subs[role].get("agent"), f"opencode.subagents.{role}.agent is required")
+        require(str(subs[role]["agent"]).strip(),
+                f"opencode.subagents.{role}.agent must be a non-empty name")
+
+    # THE agent NAME is the dispatch token AND the emitted filename (see
+    # rename_agent_files). Two roles sharing a name would collapse two different
+    # permission contracts onto one file — the read-only boundary would then depend on
+    # render order. Fail closed.
+    names = [str(subs[r]["agent"]).strip() for r in ("implementer", "reviewer", "clearance")]
+    require(len(set(names)) == len(names),
+            f"opencode.subagents.*.agent names must be DISTINCT (got {names}) — the name "
+            f"is both the dispatch token and the agent filename")
+
+    # THE load-bearing control: the two validating roles are read-only. An empty or
+    # write-capable allow-list is a fail-OPEN, so it fails the emit loudly.
+    for role in ("reviewer", "clearance"):
+        allow = ((subs[role].get("toolFilter") or {}).get("allow"))
+        require(isinstance(allow, list) and allow,
+                f"opencode.subagents.{role}.toolFilter.allow must be a NON-EMPTY list "
+                f"(read-only means an explicit read-only allow-list, not silence)")
+        bad = sorted(set(str(a).lower() for a in allow) & set(OC_FORBIDDEN_IN_READONLY_ALLOW))
+        require(not bad,
+                f"opencode.subagents.{role}.toolFilter.allow contains write/delegate "
+                f"capabilities {bad} — {role} is read-only by contract "
+                f"(forbidden: {OC_FORBIDDEN_IN_READONLY_ALLOW})")
+    require("toolFilter" not in subs["implementer"],
+            "opencode.subagents.implementer must NOT declare a toolFilter — the "
+            "implementer needs full tools (it writes code, runs tests, opens the PR)")
+
+    skills = oc.get("skills") or []
+    require(isinstance(skills, list) and skills, "opencode.skills must be a non-empty list")
+    unknown = [s for s in skills if s not in CANONICAL_VERBS]
+    require(not unknown,
+            f"opencode.skills has unknown verb(s) {sorted(unknown)}; valid: {CANONICAL_VERBS}")
+
+    # Only-Bedrock is enforced by the ALLOWLIST (`enabled_providers`), which is the
+    # only control that holds when the environment already carries ambient provider
+    # keys (ANTHROPIC_API_KEY / OPENAI_API_KEY) — those get auto-detected as providers
+    # that `disabled_providers: ["opencode"]` does NOT cover. The deny entry stays as
+    # belt-and-suspenders (it also hides the built-in Zen provider by name).
+    # Absent means "use the default"; PRESENT-but-wrong is a fail-open and must not emit.
+    disabled = oc["disabled_providers"] if "disabled_providers" in oc else ["opencode"]
+    require("opencode" in disabled,
+            "opencode.disabled_providers must include 'opencode' — hiding the built-in "
+            "Zen provider is what makes /models Bedrock-only")
+
+    model_ids = prov.get("models") or [model["model"]]
+    models = []
+    for m in model_ids:
+        if isinstance(m, dict):
+            mid, mname = m["id"], m.get("name") or _model_display_name(m["id"])
+        else:
+            mid, mname = m, _model_display_name(m)
+        _no_credential("opencode.provider.models[]", mid)
+        models.append({"id": mid, "name": mname})
+    require(models, "opencode.provider.models resolved empty")
+
+    # Per-agent deny sets, DERIVED from each role's own allow-list (FIX: the config
+    # drives the artifact — the two roles may legitimately differ).
+    reviewer_deny = derived_deny(subs["reviewer"]["toolFilter"]["allow"])
+    clearance_deny = derived_deny(subs["clearance"]["toolFilter"]["allow"])
+    for role, deny in (("reviewer", reviewer_deny), ("clearance", clearance_deny)):
+        for cap in ("edit", "bash", "task"):
+            require(cap in deny,
+                    f"opencode.subagents.{role}: derived deny set is missing {cap!r} — "
+                    f"a read-only agent must never keep write/exec/delegate")
+
+    default_ref = f"{model_provider}/{model['model']}"
+    small_ref = (f"{model_provider}/{model['small_model']}"
+                 if model.get("small_model") else default_ref)
+
+    b["scalars"].update({
+        "HOST_NOUN": "an opencode configuration",
+        "HOST_DISPATCH_NOUN": "the task tool",
+        "OC_DEFAULT_MODEL_REF": default_ref,
+        "OC_SMALL_MODEL_REF": small_ref,
+        "OC_BEDROCK_PROVIDER_ID": prov.get("id", "amazon-bedrock"),
+        "OC_BEDROCK_PROFILE": prov["profile"],
+        "OC_BEDROCK_REGION": prov["region"],
+        "OC_PRIMARY_AGENT": oc.get("primary_agent", "build"),
+        "OC_IMPLEMENTER_AGENT": subs["implementer"]["agent"],
+        "OC_IMPLEMENTER_PERSONA": subs["implementer"].get("persona", ""),
+        "OC_REVIEWER_AGENT": subs["reviewer"]["agent"],
+        "OC_REVIEWER_PERSONA": subs["reviewer"].get("persona", ""),
+        "OC_CLEARANCE_AGENT": subs["clearance"]["agent"],
+        "OC_CLEARANCE_PERSONA": subs["clearance"].get("persona", ""),
+        # Re-point the SHARED dispatch scalars at the names THIS host emits. On opencode
+        # an agent resolves by filename (agent/<name>.md) and the filename comes from
+        # subagents.<role>.agent — NOT from the verb — so a shared template that named
+        # the clearance role by verb would resolve to nothing and opencode would fall
+        # back to the full-permission primary agent.
+        "IMPLEMENTER_AGENT": subs["implementer"]["agent"],
+        "REVIEWER_AGENT": subs["reviewer"]["agent"],
+        "CLEARANCE_AGENT": subs["clearance"]["agent"],
+        "OC_REVIEWER_DENY_LIST": ", ".join(reviewer_deny),
+        "OC_CLEARANCE_DENY_LIST": ", ".join(clearance_deny),
+    })
+    b["arrays"].update({
+        # `comma` carries JSON separators so the emitted opencode.json parses.
+        "OC_MODELS": [
+            {**m, "comma": "" if i == len(models) - 1 else ","}
+            for i, m in enumerate(models)
+        ],
+        "OC_DISABLED_PROVIDERS": [
+            {"name": p, "comma": "" if i == len(disabled) - 1 else ","}
+            for i, p in enumerate(disabled)
+        ],
+        # The deny sets the read-only agent templates render, one `<cap>: deny` per
+        # line — one array per role, each derived from that role's allow-list.
+        "OC_REVIEWER_DENY": [{"cap": c} for c in reviewer_deny],
+        "OC_CLEARANCE_DENY": [{"cap": c} for c in clearance_deny],
+    })
+    b["conditionals"] = {"TARGET_CC": False, "TARGET_OPENCODE": True}
+    return b
+
+
+def rename_agent_files(out: Path, agents_dir: str, names: dict) -> int:
+    """Name each emitted agent file after its DISPATCH name (subagents.<role>.agent).
+
+    On opencode an agent is resolved by filename: `task` with `agent: <name>` loads
+    `agent/<name>.md`. If the filename came from anywhere else than the dispatch token —
+    e.g. from `verbs['gate']` — the two can disagree, the lookup misses, and opencode
+    falls back to the FULL-PERMISSION primary agent. That is a fail-OPEN of the whole
+    read-only boundary: the gate would run with edit/bash/task allowed. So the filename
+    is derived from the same scalar the skills dispatch, and the two are equal by
+    construction. `names` maps template stem (implementer/reviewer/gate) -> agent name.
+    """
+    renames = 0
+    for stem, name in names.items():
+        if name == stem:
+            continue
+        src = out / agents_dir / f"{stem}.md"
+        if src.is_file():
+            src.rename(out / agents_dir / f"{name}.md")
+            renames += 1
+    return renames
+
+
+def rename_verbs(out: Path, verbs: dict, skills_dir: str = "skills",
+                 agents_dir: str | None = "agents",
+                 commands_dir: str | None = None) -> int:
+    """Rename emitted skill dirs / commands / the gate agent file to the org's verbs.
+
+    The templates ship canonical (skills/inception, agents/gate.md); the org's `name:`
+    frontmatter is already org-rendered via {{VERB_*}}, so the invocable name is correct
+    regardless — but renaming the paths keeps the OUTPUT tidy and matching. Shared by
+    every target; only the host's directory nouns differ.
+
+    `agents_dir=None` skips the gate-agent rename — for a host where an agent file is
+    named by its DISPATCH name, not by the verb (see rename_agent_files).
+    """
+    renames = 0
+    for canon, name in verbs.items():
+        if name == canon:
+            continue
+        sd = out / skills_dir / canon
+        if sd.is_dir():
+            sd.rename(out / skills_dir / name)
+            renames += 1
+        if commands_dir:
+            cf = out / commands_dir / f"{canon}.md"
+            if cf.is_file():
+                cf.rename(out / commands_dir / f"{name}.md")
+                renames += 1
+    # the gate verb is also an agent file (on hosts that name agents by verb)
+    gate_name = verbs["gate"]
+    if agents_dir and gate_name != "gate":
+        gf = out / agents_dir / "gate.md"
+        if gf.is_file():
+            gf.rename(out / agents_dir / f"{gate_name}.md")
+            renames += 1
+    return renames
+
+
+def emit_claude_code(cfg: dict, out: Path):
+    """Target: a Claude Code plugin (skills/ + agents/ + hooks/ + .claude-plugin/)."""
     bindings = build_bindings(cfg)
-    out = Path(args.out)
     rendered = render_tree(
         bindings,
         FORGE_ROOT / "templates/org-plugin",
@@ -168,27 +435,78 @@ def main(argv=None):
         FORGE_ROOT,
         leak_check=True,
     )
+    renames = rename_verbs(out, resolve_verbs(cfg))
+    return rendered, renames
 
-    # Rename emitted skill dirs / the gate agent file to the org's verb names. The
-    # templates ship canonical (skills/inception, agents/gate.md); the org's `name:`
-    # frontmatter is already org-rendered via {{VERB_*}}, so the invocable name is
-    # correct regardless — but renaming the paths keeps the OUTPUT tidy and matching.
-    verbs = resolve_verbs(cfg)
-    renames = 0
-    for canon, name in verbs.items():
-        if name == canon:
-            continue
-        sd = out / "skills" / canon
-        if sd.is_dir():
-            sd.rename(out / "skills" / name)
-            renames += 1
-    # the gate verb is also an agent file
-    gate_name = verbs["gate"]
-    if gate_name != "gate":
-        gf = out / "agents" / "gate.md"
-        if gf.is_file():
-            gf.rename(out / "agents" / f"{gate_name}.md")
-            renames += 1
+
+def emit_opencode(cfg: dict, out: Path):
+    """Target: an opencode configuration (opencode.json + agent/ + command/ + skill/).
+
+    Two passes. Pass 1 renders the opencode-specific packaging. Pass 2 folds the SHARED
+    skill bodies (the same templates the Claude Code target renders) into skill/<verb>/,
+    so a skill's prose is byte-identical across targets except where a {{#TARGET_*}}
+    conditional or a host-noun scalar deliberately differs.
+    """
+    bindings = build_bindings_opencode(cfg)
+    rendered = render_tree(
+        bindings,
+        FORGE_ROOT / "templates/opencode",
+        out,
+        FORGE_ROOT,
+        leak_check=True,
+        clean=True,
+    )
+    for canon in cfg["opencode"]["skills"]:
+        src = FORGE_ROOT / "templates/org-plugin/skills" / canon
+        require(src.is_dir(), f"opencode.skills: no shared skill template for '{canon}'")
+        rendered += render_tree(
+            bindings, src, out / "skill" / canon, FORGE_ROOT,
+            leak_check=True, clean=False,
+        )
+    # command/ and skill/ ARE verb-named; agent/ is NOT (agents_dir=None) — an agent
+    # file is named by its dispatch token so the skills' `task` calls resolve.
+    renames = rename_verbs(out, resolve_verbs(cfg), skills_dir="skill",
+                           agents_dir=None, commands_dir="command")
+    sc = bindings["scalars"]
+    agent_names = {
+        "implementer": sc["OC_IMPLEMENTER_AGENT"],
+        "reviewer": sc["OC_REVIEWER_AGENT"],
+        "gate": sc["OC_CLEARANCE_AGENT"],
+    }
+    renames += rename_agent_files(out, "agent", agent_names)
+
+    # Post-render assertions on the artifact itself, not on the config.
+    for role, name in agent_names.items():
+        require((out / "agent" / f"{name}.md").is_file(),
+                f"agent/{name}.md is missing — the {role} dispatch name does not resolve "
+                f"to an emitted agent file (opencode would fall back to the "
+                f"full-permission primary agent)")
+    conf = json.loads((out / "opencode.json").read_text())
+    require(conf.get("enabled_providers") == [sc["OC_BEDROCK_PROVIDER_ID"]],
+            f"opencode.json enabled_providers must be exactly "
+            f"[{sc['OC_BEDROCK_PROVIDER_ID']!r}] — the allowlist is the only-Bedrock "
+            f"control that survives an ambient ANTHROPIC_API_KEY/OPENAI_API_KEY "
+            f"(got {conf.get('enabled_providers')!r})")
+    return rendered, renames
+
+
+TARGETS = {
+    "claude-code": emit_claude_code,
+    "opencode": emit_opencode,
+}
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="forge emit driver")
+    ap.add_argument("--config", default=".forge.org.yaml")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--target", default="claude-code", choices=sorted(TARGETS),
+                    help="host to emit for (default: claude-code)")
+    args = ap.parse_args(argv)
+
+    cfg = yaml.safe_load(Path(args.config).read_text())
+    out = Path(args.out)
+    rendered, renames = TARGETS[args.target](cfg, out)
 
     print(f"OK emitted {cfg['plugin']['name']} v{cfg['plugin']['version']} "
           f"→ {args.out} ({len(rendered)} files, {renames} verb renames)")

--- a/lib/render.py
+++ b/lib/render.py
@@ -100,13 +100,20 @@ def _render_scalars(text: str, scalars: dict) -> str:
 
 
 def render_tree(bindings: dict, templates_dir: Path, out_dir: Path,
-                forge_root: Path, leak_check: bool = False) -> list[Path]:
-    """Render every *.template under templates_dir into out_dir. Returns paths."""
+                forge_root: Path, leak_check: bool = False,
+                clean: bool = True) -> list[Path]:
+    """Render every *.template under templates_dir into out_dir. Returns paths.
+
+    `clean` (default True) wipes out_dir first — the behaviour every single-pass
+    render wants. A multi-pass emitter (one that folds a SHARED template tree into
+    a subdirectory of an already-rendered target tree) passes clean=False so the
+    second pass does not delete the first pass's output.
+    """
     scalars = resolve_snippets(bindings, forge_root)
     arrays = bindings.get("arrays", {})
     conditionals = bindings.get("conditionals", {})
 
-    if out_dir.exists():
+    if clean and out_dir.exists():
         shutil.rmtree(out_dir)
     rendered = []
     for tpl in sorted(templates_dir.rglob("*.template")):

--- a/templates/opencode/AGENTS.md.template
+++ b/templates/opencode/AGENTS.md.template
@@ -1,0 +1,30 @@
+# {{ORG_NAME}} — session preamble
+
+{{PLUGIN_NAME}} is {{ORG_NAME}}'s agent harness. This file is a **pointer**, not the
+process: the operating model lives in the org brain (`{{ORG_WIKI_NAME}}`) and is read at
+runtime, so it can change without re-emitting this configuration.
+
+- **Run `/{{VERB_PRIME}}` first, every session.** It loads the operating model, the wiki
+  schema, the compliance guardrails, and the relevant decisions from
+  `{{ORG_WIKI_NAME}}`, then tells you in a few lines what process is in force.
+- **The brain is at** `${{ORG_WIKI_PATH_ENV}}` (falling back to
+  `{{ORG_WIKI_DEFAULT_PATH}}`). If the two ever disagree with this file, the wiki wins.
+- **New here?** `/{{VERB_INTRO}}` is the one-screen orientation.
+- **Model floor ({{ORG_NAME}}):** default **{{MODEL_POLICY_DEFAULT}}**; banned:
+  **{{MODEL_POLICY_BANNED}}**. {{MODEL_POLICY_RULE}}
+- **Models: Bedrock only.** `opencode.json` carries
+  `"enabled_providers": ["{{OC_BEDROCK_PROVIDER_ID}}"]` — an **allowlist**, so only
+  `{{OC_BEDROCK_PROVIDER_ID}}` is offered even on a machine with an ambient
+  `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` that opencode would otherwise auto-detect as a
+  provider. (`disabled_providers` is kept alongside it; a deny-list is the weaker control
+  because it only covers providers someone thought to name.)
+- **The validating agents are read-only** via a `permission: <cap>: deny` block derived
+  from each role's allow-list in the org config: `{{OC_REVIEWER_AGENT}}` denies
+  `{{OC_REVIEWER_DENY_LIST}}`; `{{OC_CLEARANCE_AGENT}}` denies `{{OC_CLEARANCE_DENY_LIST}}`.
+  Dispatch them by **those exact names** — a `task` agent name with no matching file in
+  `agent/` falls back to the full-permission primary agent and the boundary is gone.
+- **`plugin/reminders.js` is an inert stub** — it binds no events and prints nothing. A
+  placeholder for future advisory (never blocking) nudges, not a live surface.
+
+Everything else — the verbs, the agent contracts, the gates — is described where it
+lives: `command/`, `agent/`, and `skill/`.

--- a/templates/opencode/README.md.template
+++ b/templates/opencode/README.md.template
@@ -1,0 +1,97 @@
+# {{PLUGIN_NAME}} — {{ORG_NAME}}'s agent harness, as an opencode configuration
+
+This directory *is* the configuration. It ships the same harness {{ORG_NAME}} runs
+elsewhere — the verbs, the agent contracts, the gates — packaged for **opencode**.
+
+> **Owned by {{ORG_NAME}}.** It is generated, but it is yours: identity, version and
+> distribution are the org's, and nothing here is a runtime dependency on a generator.
+
+## Install
+
+**Globally** (every project on this machine):
+
+```
+cp -R ./ ~/.config/opencode/
+```
+
+**Or per repo** (checked in, so a team shares one harness):
+
+```
+mkdir -p <repo>/.opencode && cp -R ./ <repo>/.opencode/
+```
+
+Either way the layout is the same:
+
+```
+opencode.json    provider + model + the only-Bedrock allowlist
+AGENTS.md        session preamble (points at the wiki; run /{{VERB_PRIME}} first)
+command/         {{VERB_INTRO}} · {{VERB_SETUP}} · {{VERB_PRIME}} · {{VERB_INCEPTION}} · {{VERB_REFINE}} · {{VERB_EXECUTE}} · {{VERB_WIKI}} · {{VERB_HANDOFF}}
+agent/           {{OC_IMPLEMENTER_AGENT}} · {{OC_REVIEWER_AGENT}} · {{OC_CLEARANCE_AGENT}} (the roles `task` dispatches, one file per name)
+skill/           the procedure each command reads and follows
+plugin/          reminders.js — a NO-OP stub (see below), not an active surface
+```
+
+**Restart opencode after copying.** Config, agents, commands and plugins are read at
+startup — an already-running session will not see them.
+
+## Authenticate (no API keys anywhere)
+
+The provider is Amazon Bedrock through your **ambient AWS credential chain**. There is no
+key in `opencode.json` — only a profile *name* and a region. Log in before you start:
+
+```
+aws sso login --profile {{OC_BEDROCK_PROFILE}}
+```
+
+Region: `{{OC_BEDROCK_REGION}}`. Default model: `{{OC_DEFAULT_MODEL_REF}}`.
+If a session says it cannot reach the model, your SSO session has almost certainly
+expired — run the login again.
+
+## Only Bedrock
+
+The load-bearing control is the **allowlist**: `opencode.json` sets
+
+```
+"enabled_providers": ["{{OC_BEDROCK_PROVIDER_ID}}"]
+```
+
+so `/models` lists **only** `{{OC_BEDROCK_PROVIDER_ID}}` — including on a machine that
+already has an `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` in its environment, which opencode
+would otherwise auto-detect as extra providers. `"disabled_providers": ["opencode"]` is
+kept as belt-and-suspenders (it names the built-in Zen provider explicitly), but a
+deny-list alone does **not** cover a provider you did not think to name — the allowlist
+does. All model traffic therefore goes through {{ORG_NAME}}'s own account, and the CRIS
+model ids declared under `provider.{{OC_BEDROCK_PROVIDER_ID}}.models` are what you may pick.
+
+## The read-only boundary
+
+`agent/{{OC_REVIEWER_AGENT}}.md` denies `{{OC_REVIEWER_DENY_LIST}}`; `agent/{{OC_CLEARANCE_AGENT}}.md`
+denies `{{OC_CLEARANCE_DENY_LIST}}`. A denied permission removes the tool from the model's
+toolset *and* refuses at execution — so a validating agent cannot edit code, run a
+command, or spawn a writer to do it for them. `{{OC_IMPLEMENTER_AGENT}}` deliberately has
+no `permission` block: it needs full tools to do the work.
+
+Each deny set is **derived at emit time** from that agent's own read-only allow-list in
+the org config (deny = the dangerous capabilities it does not allow), so the config is
+what decides the artifact — not a hardcoded list in a template.
+
+**The filename is the contract.** `task` resolves an agent by file name, and a name that
+does not resolve falls back to the full-permission primary agent (`{{OC_PRIMARY_AGENT}}`)
+— which would silently run a "read-only" gate with edit/bash/task allowed. So these files
+are named after the exact tokens the skills dispatch; renaming one by hand breaks the
+boundary. Rename in the org config and re-emit instead.
+
+## `plugin/reminders.js` — a stub, not a feature
+
+It ships **inert on purpose**: its `TRIGGERS` map is empty, so it binds no event and
+prints nothing. It is a placeholder for advisory (never blocking) session nudges, to be
+wired once the event names are verified against your opencode version. Do not describe
+the reminders as an active surface — today they are a planned no-op.
+
+## Where behavior comes from
+
+Read from the wiki at prime, never baked here:
+
+{{#PRIME_READS}}
+- `{{ORG_WIKI_NAME}}/{{.}}`
+{{/PRIME_READS}}

--- a/templates/opencode/agent/gate.md.template
+++ b/templates/opencode/agent/gate.md.template
@@ -1,0 +1,88 @@
+---
+description: Validation agent that checks a ticket or PR against the org's gate rules at one of three points — agent-ready, execution-ready, or pre-merge. Validates artifacts it did not author.
+mode: subagent
+model: {{OC_DEFAULT_MODEL_REF}}
+permission:
+{{#OC_CLEARANCE_DENY}}
+  {{cap}}: deny
+{{/OC_CLEARANCE_DENY}}
+---
+
+# Gate — `{{OC_CLEARANCE_AGENT}}`
+
+**You are a role, not a standalone session.** `{{VERB_REFINE}}` and `{{VERB_EXECUTE}}`
+invoke you through the `task` tool as `{{OC_CLEARANCE_AGENT}}` — this file's name, which is
+why the dispatch resolves here and not to the primary agent — at the gate points. This
+file is your role contract.
+{{OC_CLEARANCE_PERSONA}}
+
+You validate against the org's **gate rules**, which live in the wiki (read them; do
+not hardcode them — they evolve). You run in your own context and judge artifacts you
+did not produce. You return a verdict + a precise deficiency list; you do not fix
+anything and you do not decide to waive a gate — that is the engineer's call.
+
+**You are read-only by construction.** The frontmatter above denies
+`{{OC_CLEARANCE_DENY_LIST}}`: a denied permission is removed from your toolset *and*
+refused at execution. `task` is denied on purpose — a gate that can spawn a writer can
+fix the thing it is supposed to fail.
+
+You are invoked in one of three modes.
+
+## Mode: `agent-ready` (called by `{{VERB_REFINE}}`)
+
+Is a ticket specified well enough for an agent to execute without guessing? Check
+against the wiki's refine/agent-ready rules — typically:
+
+- A user-facing need is stated.
+- A validation/acceptance test (the outer goal) is defined and, where required,
+  signed off by product.
+- SLOs are declared (user-facing) with baselines.
+- Acceptance criteria are concrete and testable.
+- A proposed architecture and a security analysis exist.
+- Design-controls traceability is identified, if the touched repo is regulated.
+
+## Mode: `execution-ready` (called by `{{VERB_EXECUTE}}`)
+
+Is a decomposition safe to dispatch? Check:
+
+- Every acceptance criterion is covered by at least one task.
+- Task dependencies form a valid DAG (no cycles).
+- Each task carries enough scoped context to execute in isolation.
+- Constitution constraints are specified per task.
+- Feature-flag alignment across producer/consumer tasks is clear.
+
+## Mode: `pre-merge` (continuous-compliance gate)
+
+Is a PR safe to merge to main? Check, per the wiki's gate rules:
+
+- Validation/acceptance test green.
+- Verification tests green.
+- REQ/SPEC (design-controls artifacts) present and consistent, if regulated.
+- SLOs declared and not regressed.
+- Security analysis addressed.
+- Traceability intact (need → spec → test → change).
+
+## You produce
+
+A structured verdict:
+
+- **status**: `pass` | `fail`
+- **deficiencies**: a specific, actionable list (each: what's missing, where, what
+  would satisfy it). Empty on pass.
+
+Return it to the caller (`{{VERB_REFINE}}`, `{{VERB_EXECUTE}}`, or CI) as those lines and
+nothing more. The caller + engineer decide what to do — you only judge.
+
+## Boundaries
+
+- **Read-only.** You never edit the ticket, the spec, or the code.
+- You check against the **wiki's current gate rules**, not a baked-in checklist — if
+  the wiki's rules changed, your checks change with them.
+- You do not waive or override a gate. A failing gate stops the flow until a human
+  decides.
+
+## Anti-patterns
+
+- Passing a gate to be helpful when a criterion is genuinely unmet.
+- Inventing criteria the wiki doesn't define.
+- Vague deficiencies ("needs more detail") instead of specific, fixable ones.

--- a/templates/opencode/agent/implementer.md.template
+++ b/templates/opencode/agent/implementer.md.template
@@ -1,0 +1,72 @@
+---
+description: TDD agent that executes one scoped task in one repo and opens a PR. Never reviews its own work.
+mode: subagent
+model: {{OC_DEFAULT_MODEL_REF}}
+---
+
+# Implementer
+
+**You are a role, not a standalone session.** `{{VERB_EXECUTE}}` invokes you through the
+`task` tool, one invocation per scoped task, in your own context. This file is your role
+contract. {{OC_IMPLEMENTER_PERSONA}}
+
+You execute **one scoped task within a single repo**, using strict TDD. You were
+dispatched by `{{VERB_EXECUTE}}` with a context envelope — that envelope is your whole world.
+Do not reach beyond it.
+
+## You receive
+
+- The task spec: acceptance criteria, test expectations, scope boundaries.
+- The target repo: name, branch, working tree.
+- The constitution constraints that apply to this task (read them; they are not
+  negotiable here — they come from the org wiki).
+- Feature-flag instructions, if any.
+
+Pull T2/T3 detail (API contracts at boundaries, existing patterns, related tests)
+**only when the task needs it** — not up front.
+
+## Discipline (non-negotiable)
+
+- **Write the failing test first.** No exceptions. The test proves an acceptance
+  criterion.
+- **Simplest code to pass.** Then refactor while green.
+- **Structure and behavior never share a commit** — tidying commit separate from
+  behavior commit.
+- **Use feature flags** for new behavior, per the task's flag instructions.
+- **Stay in scope.** Do not touch code outside your assigned concern. If the task
+  can't be done without going wider, **stop and escalate** — do not expand silently.
+- **Work on the branch you were given.** You get a dedicated branch in the target repo,
+  not a private working tree; do not switch branches or touch another task's branch.
+
+## Workflow
+
+1. Read the task spec + test expectations.
+2. Write failing tests proving the acceptance criteria (red).
+3. Implement the simplest passing code (green).
+4. Refactor while green.
+5. Commit: structure-only and behavior-only commits, separated.
+6. Open a PR on the target repo with all CI passing, linked to the task/ticket.
+7. Report back **only** the result lines: PR URL, status, any blockers. Your reasoning
+   and the diff stay in your context — the orchestrator holds conclusions, not contents.
+
+## Isolation — no self-review
+
+You **never** review or merge your own PR. A separate `{{OC_REVIEWER_AGENT}}` agent
+validates it in its own context, dispatched as its own `task` call. Writing tests first
+is part of this discipline: it stops you anchoring the implementation to your own
+assumptions.
+
+## Escalate, don't override
+
+If a constitution rule seems to block the task (e.g. "no flag exists for this"), or
+you'd need to leave scope, or an acceptance criterion is untestable as written —
+**escalate to `{{VERB_EXECUTE}}`** with the specific deficiency. Do not relax a rule on your
+own.
+
+## Anti-patterns
+
+- Touching code outside the task scope.
+- Skipping the failing-test-first step.
+- Combining structure and behavior in one commit.
+- Self-merging because "review is slow."
+- Adding a test that doesn't actually test the acceptance criterion.

--- a/templates/opencode/agent/reviewer.md.template
+++ b/templates/opencode/agent/reviewer.md.template
@@ -1,0 +1,76 @@
+---
+description: Read-only agent that validates an implementer's PR against the org's constitution and the task spec. Runs in a separate context — never authored the code it reviews.
+mode: subagent
+model: {{OC_DEFAULT_MODEL_REF}}
+permission:
+{{#OC_REVIEWER_DENY}}
+  {{cap}}: deny
+{{/OC_REVIEWER_DENY}}
+---
+
+# Reviewer
+
+**You are a role, not a standalone session.** `{{VERB_EXECUTE}}` invokes you through the
+`task` tool as a **separate invocation** from the implementer. This file is your role
+contract; your separateness from the implementer's context *is* the no-self-review
+guarantee. {{OC_REVIEWER_PERSONA}}
+
+You validate a PR opened by an `{{OC_IMPLEMENTER_AGENT}}` agent. You run in a **separate
+context** and see only the **diff + the task spec** — never the implementer's reasoning.
+That isolation is the whole point: you can't anchor on logic you never saw.
+
+**You are read-only by construction.** The frontmatter above denies
+`{{OC_REVIEWER_DENY_LIST}}`: a denied permission is removed from your toolset *and*
+refused at execution, so you cannot modify the code, run a command, or delegate a write
+to another agent. `task` is denied on purpose — a reviewer that can spawn an implementer
+is not read-only. If a check genuinely needs a write or a command, that is a deficiency
+to report, not a permission to seek.
+
+## You receive
+
+- The PR diff and commit messages.
+- The task spec: acceptance criteria, test expectations, SLO targets, feature-flag
+  instructions.
+- The constitution rules to check against (from the org wiki).
+- CI/CD results.
+
+Pull SLO baselines or cross-repo context (related PRs, flag alignment, deployment
+ordering) at T2 **only** when a check needs it.
+
+## What you check
+
+- **TDD discipline** — tests exist and genuinely prove the acceptance criteria
+  (not vacuous); they were written to drive the change, not bolted on.
+- **Commit discipline** — structure and behavior are in separate commits.
+- **Acceptance criteria** — each is satisfied and traceable to a test.
+- **SLO compliance** — the change doesn't put the affected surface's latency / error
+  / availability targets at risk.
+- **Feature flags** — present and correct per the task instructions.
+- **Design controls** — if the repo is under design controls, the
+  requirement→spec→test records the task required are present.
+- **Scope** — the diff stays within the task's concern.
+
+## You produce
+
+- A single verdict line — `PASS` or `FAIL` — plus, on FAIL, **specific** deficiencies
+  (what, where, what would satisfy it). Return the verdict and the deficiencies only;
+  the orchestrator must not have to read your transcript.
+- An escalation to `{{VERB_EXECUTE}}` if you find an unacceptable issue (TDD violated, commit
+  discipline broken, SLO at risk, out-of-scope changes).
+
+## Boundaries
+
+- **Read-only on code and CI.** You never modify code or commit. You validate and
+  report.
+- You do **not** decide to override a failed check — that judgment is `{{VERB_EXECUTE}}`'s,
+  with the engineer. You surface the deficiency precisely; the loop decides.
+- You review against the **task spec and the wiki's rules as they are**, not your own
+  preferences.
+
+## Anti-patterns
+
+- Rubber-stamping ("LGTM") without checking tests against the acceptance criteria.
+- Rewriting the code yourself instead of requesting changes.
+- Asking another agent to make the change for you.
+- Pulling the implementer's reasoning into your context — you judge the diff.
+- Inventing rules not in the constitution.

--- a/templates/opencode/command/execute.md.template
+++ b/templates/opencode/command/execute.md.template
@@ -1,0 +1,12 @@
+---
+description: Decompose an agent-ready {{ORG_NAME}} story into scoped tasks, dispatch agents with isolated context, monitor progress, and sync status to the tracker.
+agent: {{OC_PRIMARY_AGENT}}
+model: {{OC_DEFAULT_MODEL_REF}}
+---
+
+Read `skill/{{VERB_EXECUTE}}/SKILL.md` and follow it as a procedure — it is the authoritative
+version of this verb; this file is only the entry point.
+
+You are the long-lived orchestrator: dispatch with the `task` tool, consume only the result lines, and stay top-of-loop.
+
+$ARGUMENTS

--- a/templates/opencode/command/handoff.md.template
+++ b/templates/opencode/command/handoff.md.template
@@ -1,0 +1,12 @@
+---
+description: Cycle a long session cleanly: route durable knowledge to the wiki, save working state, and emit a prime prompt for a fresh session.
+agent: {{OC_PRIMARY_AGENT}}
+model: {{OC_DEFAULT_MODEL_REF}}
+---
+
+Read `skill/{{VERB_HANDOFF}}/SKILL.md` and follow it as a procedure — it is the authoritative
+version of this verb; this file is only the entry point.
+
+The inverse of {{VERB_PRIME}}.
+
+$ARGUMENTS

--- a/templates/opencode/command/inception.md.template
+++ b/templates/opencode/command/inception.md.template
@@ -1,0 +1,12 @@
+---
+description: Kick off a brand-new {{ORG_NAME}} project: map it across repos, originate the epic/story backlog, scaffold the workspace repo index.
+agent: {{OC_PRIMARY_AGENT}}
+model: {{OC_DEFAULT_MODEL_REF}}
+---
+
+Read `skill/{{VERB_INCEPTION}}/SKILL.md` and follow it as a procedure — it is the authoritative
+version of this verb; this file is only the entry point.
+
+This is a deep-judgment verb; think before you write to the tracker.
+
+$ARGUMENTS

--- a/templates/opencode/command/intro.md.template
+++ b/templates/opencode/command/intro.md.template
@@ -1,0 +1,12 @@
+---
+description: Orient someone new to {{PLUGIN_NAME}} — what it is, what it can do, how to start.
+agent: {{OC_PRIMARY_AGENT}}
+model: {{OC_DEFAULT_MODEL_REF}}
+---
+
+Read `skill/{{VERB_INTRO}}/SKILL.md` and follow it as a procedure — it is the authoritative
+version of this verb; this file is only the entry point.
+
+Walk the user through the orientation conversationally; do not dump the file.
+
+$ARGUMENTS

--- a/templates/opencode/command/prime.md.template
+++ b/templates/opencode/command/prime.md.template
@@ -1,0 +1,12 @@
+---
+description: Calibrate this session: read the operating model, schema, compliance and relevant decisions from {{ORG_WIKI_NAME}}. Run first, every session.
+agent: {{OC_PRIMARY_AGENT}}
+model: {{OC_DEFAULT_MODEL_REF}}
+---
+
+Read `skill/{{VERB_PRIME}}/SKILL.md` and follow it as a procedure — it is the authoritative
+version of this verb; this file is only the entry point.
+
+Report the calibration summary at T1 — a few lines, not the wiki's contents.
+
+$ARGUMENTS

--- a/templates/opencode/command/refine.md.template
+++ b/templates/opencode/command/refine.md.template
@@ -1,0 +1,12 @@
+---
+description: Take a {{ORG_NAME}} ticket from idea to agent-ready: constraints, SLOs, the acceptance/validation test, proof design, dependencies.
+agent: {{OC_PRIMARY_AGENT}}
+model: {{OC_DEFAULT_MODEL_REF}}
+---
+
+Read `skill/{{VERB_REFINE}}/SKILL.md` and follow it as a procedure — it is the authoritative
+version of this verb; this file is only the entry point.
+
+Write the refinement artifacts back to the tracker as you go.
+
+$ARGUMENTS

--- a/templates/opencode/command/setup.md.template
+++ b/templates/opencode/command/setup.md.template
@@ -1,0 +1,12 @@
+---
+description: One-time bootstrap: clone the {{ORG_NAME}} org brain into this directory and point the harness at it.
+agent: {{OC_PRIMARY_AGENT}}
+model: {{OC_DEFAULT_MODEL_REF}}
+---
+
+Read `skill/{{VERB_SETUP}}/SKILL.md` and follow it as a procedure — it is the authoritative
+version of this verb; this file is only the entry point.
+
+Run this once in a fresh directory, before {{VERB_PRIME}}.
+
+$ARGUMENTS

--- a/templates/opencode/command/wiki.md.template
+++ b/templates/opencode/command/wiki.md.template
@@ -1,0 +1,12 @@
+---
+description: Read the {{ORG_NAME}} org brain (`query`) or contribute a decision/learning back to it (`contribute`).
+agent: {{OC_PRIMARY_AGENT}}
+model: {{OC_DEFAULT_MODEL_REF}}
+---
+
+Read `skill/{{VERB_WIKI}}/SKILL.md` and follow it as a procedure — it is the authoritative
+version of this verb; this file is only the entry point.
+
+Ask which mode is meant if the invocation does not say.
+
+$ARGUMENTS

--- a/templates/opencode/opencode.json.template
+++ b/templates/opencode/opencode.json.template
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "enabled_providers": ["{{OC_BEDROCK_PROVIDER_ID}}"],
+  "disabled_providers": [
+{{#OC_DISABLED_PROVIDERS}}
+    "{{name}}"{{comma}}
+{{/OC_DISABLED_PROVIDERS}}
+  ],
+  "model": "{{OC_DEFAULT_MODEL_REF}}",
+  "small_model": "{{OC_SMALL_MODEL_REF}}",
+  "default_agent": "{{OC_PRIMARY_AGENT}}",
+  "instructions": ["AGENTS.md"],
+  "provider": {
+    "{{OC_BEDROCK_PROVIDER_ID}}": {
+      "options": {
+        "region": "{{OC_BEDROCK_REGION}}",
+        "profile": "{{OC_BEDROCK_PROFILE}}"
+      },
+      "models": {
+{{#OC_MODELS}}
+        "{{id}}": { "name": "{{name}}" }{{comma}}
+{{/OC_MODELS}}
+      }
+    }
+  }
+}

--- a/templates/opencode/plugin/reminders.js.template
+++ b/templates/opencode/plugin/reminders.js.template
@@ -1,0 +1,56 @@
+/**
+ * {{PLUGIN_NAME}} — advisory session reminders for {{ORG_NAME}}.
+ *
+ * ADVISORY ONLY. This plugin never blocks, never auto-acts, and never edits anything:
+ * it surfaces at most one short line so the human stays top-of-loop (dumb pipes, smart
+ * endpoints). Every handler is wrapped so a failure here can NEVER break a session —
+ * it fails OPEN, silently.
+ *
+ * What it is meant to nudge, mirroring the harness's three reminders:
+ *   - session start      -> run `/{{VERB_PRIME}}` first (loads {{ORG_WIKI_NAME}}).
+ *   - context filling    -> `/{{VERB_HANDOFF}}` to cycle the session cleanly.
+ *   - session end        -> route durable knowledge to the wiki via `/{{VERB_WIKI}}`.
+ *
+ * The event names below are intentionally NOT hardcoded: this build ships as a
+ * well-formed no-op that inspects the event bus and logs nothing unless a name matches.
+ * Bind the reminders by adding the exact event names your opencode version emits to
+ * TRIGGERS (verify them against `opencode` itself — do not guess), e.g. a session /
+ * lifecycle event for start, a compaction event for the handoff nudge, and a session
+ * idle / end event for the wiki nudge. Until then the plugin is inert BY DESIGN, which
+ * is the safe default for an advisory-only surface.
+ */
+
+const REMINDERS = {
+  start: "Run /{{VERB_PRIME}} first — it loads the {{ORG_NAME}} operating model from {{ORG_WIKI_NAME}}.",
+  compact: "Context is filling — /{{VERB_HANDOFF}} cycles this session without losing your place.",
+  end: "Anything durable learned here belongs in {{ORG_WIKI_NAME}} — /{{VERB_WIKI}} contribute.",
+};
+
+// event name -> reminder key. EMPTY = inert. Fill in after verifying the names.
+const TRIGGERS = {};
+
+/** @type {import("@opencode-ai/plugin").Plugin} */
+export const Reminders = async () => {
+  const notice = (key) => {
+    try {
+      const text = REMINDERS[key];
+      if (text) console.log(`[{{PLUGIN_NAME}}] ${text}`);
+    } catch {
+      /* fail open: an advisory nudge must never break a session */
+    }
+  };
+
+  return {
+    event: async (input) => {
+      try {
+        const name = input && input.event && input.event.type;
+        const key = name ? TRIGGERS[name] : undefined;
+        if (key) notice(key);
+      } catch {
+        /* fail open */
+      }
+    },
+  };
+};
+
+export default Reminders;

--- a/templates/org-plugin/skills/execute/SKILL.md.template
+++ b/templates/org-plugin/skills/execute/SKILL.md.template
@@ -1,6 +1,6 @@
 ---
 name: {{VERB_EXECUTE}}
-description: Decompose an agent-ready {{ORG_NAME}} story into scoped tasks, dispatch agents (implementer/reviewer) with isolated context, monitor progress, and sync status to the tracker. The tracker is the bus.
+description: Decompose an agent-ready {{ORG_NAME}} story into scoped tasks, dispatch agents ({{IMPLEMENTER_AGENT}}/{{REVIEWER_AGENT}}) with isolated context, monitor progress, and sync status to the tracker. The tracker is the bus.
 ---
 
 # /{{VERB_EXECUTE}} — Agent-ready story → shipped work ({{ORG_NAME}})
@@ -73,12 +73,13 @@ flag instructions, and its dependencies.
 
 ### 4. Validate via the execution-ready gate
 
-Dispatch the **{{VERB_GATE}}** agent in `execution-ready` mode: every acceptance criterion is
+Dispatch the **{{CLEARANCE_AGENT}}** agent in `execution-ready` mode: every acceptance criterion is
 covered by some task, the dependency graph is a valid DAG, each task carries enough
 context to execute, constitution constraints are specified, and feature-flag
 alignment across producer/consumer tasks is clear. Iterate with the engineer until
 the gate passes.
 
+{{#TARGET_CC}}
 ### 5. Dispatch agents as a Workflow (scoped, isolated context)
 
 Run the wave as a **Workflow** (Claude Code's `Workflow` tool) — the orchestrator's
@@ -132,6 +133,39 @@ land on a banned model. **Model floor for this org:** default **{{MODEL_POLICY_D
 banned: **{{MODEL_POLICY_BANNED}}**. {{MODEL_POLICY_RULE}} If a stage genuinely needs a
 one-off (non-archetype) agent, it MUST set `model` explicitly — never leave it implicit.
 We optimize for value-per-token, not cheapest token.
+{{/TARGET_CC}}
+{{#TARGET_OPENCODE}}
+### 5. Dispatch agents via the `task` tool (scoped, isolated context)
+
+Dispatch each unit of work with the **`task` tool**, naming the agent to run it —
+`{{OC_IMPLEMENTER_AGENT}}`, `{{OC_REVIEWER_AGENT}}`, or `{{OC_CLEARANCE_AGENT}}`. Each
+`task` call is a **fresh subagent context**; this session stays the single long-lived
+orchestrator holding the plan and the tracker.
+
+For each ready task, dispatch **`{{OC_IMPLEMENTER_AGENT}}`** with a context envelope
+containing **only**: the task spec, the target repo + branch, test expectations, the
+applicable constitution rules, and feature-flag instructions. Do **not** pre-load
+sibling-task context — isolation is what keeps agents honest and cheap.
+
+When an implementer opens its PR, dispatch **`{{OC_REVIEWER_AGENT}}`** as a **second,
+separate `task` call** that sees only the diff + task spec — never the implementer's
+reasoning. **No-self-review is structural here:** two `task` invocations, two contexts,
+and the reviewer agent is read-only by permission (`{{OC_REVIEWER_DENY_LIST}}` all
+denied), so it *cannot* edit the diff it judges even if asked. A single agent that
+implements then reviews its own diff in one context is the forbidden anti-pattern.
+
+**Isolation is branch-per-task, not worktrees.** There is **no worktree hook on this
+host** — nothing creates or resolves a per-agent worktree, so do not ask for one. Give
+each task its **own branch in the target repo** (`<ticket>-<concern>`) and dispatch at
+most one implementer per repo at a time; parallelize *across* repos, serialize *within*
+one. Say this in the envelope so the agent branches instead of assuming a private tree.
+
+**Always dispatch by agent name — never an ad-hoc, agent-less `task`.** The agent
+definitions (`agent/`) pin `model` and the permission set, so naming the agent is what
+guarantees both the depth and the read-only boundary. **Model floor for this org:**
+default **{{MODEL_POLICY_DEFAULT}}**; banned: **{{MODEL_POLICY_BANNED}}**.
+{{MODEL_POLICY_RULE}} We optimize for value-per-token, not cheapest token.
+{{/TARGET_OPENCODE}}
 
 **Context economy — keep the orchestrator lean.** You are the one long-lived context;
 every token a stage pours into it is permanent. So make each stage **return only

--- a/templates/org-plugin/skills/intro/SKILL.md.template
+++ b/templates/org-plugin/skills/intro/SKILL.md.template
@@ -9,7 +9,7 @@ description: Introduce {{PLUGIN_NAME}} to someone new — what it is, what it ca
 
 ## What {{PLUGIN_NAME}} is
 
-{{PLUGIN_NAME}} is **{{ORG_NAME}}'s agent harness** — a Claude Code plugin that helps
+{{PLUGIN_NAME}} is **{{ORG_NAME}}'s agent harness** — {{HOST_NOUN}} that helps
 you take work from a rough idea to a shipped, verified change, the way {{ORG_NAME}}
 actually works.
 
@@ -52,8 +52,8 @@ orchestrating session itself can sit at **medium**. `{{VERB_SETUP}}`/`{{VERB_PRI
 light. *(the `{{VERB_EXECUTE}}` level is a starting point — bump it if decomposition feels
 under-thought.)*
 
-> **Why the agents don't appear here:** `implementer` / `reviewer` / `{{VERB_GATE}}` are **roles
-> instantiated by Workflow stages**, not skills you invoke. Their model + effort are
+> **Why the agents don't appear here:** `{{IMPLEMENTER_AGENT}}` / `{{REVIEWER_AGENT}}` / `{{CLEARANCE_AGENT}}` are **roles
+> instantiated by {{HOST_DISPATCH_NOUN}}**, not skills you invoke. Their model + effort are
 > fixed in their definitions — you never set effort for them by hand.
 
 ## The shape of the work

--- a/templates/org-plugin/skills/refine/SKILL.md.template
+++ b/templates/org-plugin/skills/refine/SKILL.md.template
@@ -83,7 +83,7 @@ tracker is the system of record, not this session. Keep the session lean.
 
 ### 7. Check agent-readiness (optional, on demand)
 
-Dispatch the **{{VERB_GATE}}** agent in `agent-ready` mode to assess gaps against the wiki's
+Dispatch the **{{CLEARANCE_AGENT}}** agent in `agent-ready` mode to assess gaps against the wiki's
 gate rules. It returns a readiness verdict + a deficiency list. Iterate until clean.
 
 **Do not** pass this gate without a defined validation/acceptance test — that test is

--- a/tests/test_opencode_emit.py
+++ b/tests/test_opencode_emit.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python3
+"""`emit --target opencode` — the second emit target.
+
+One org config, N hosts. These tests hold the multi-target abstraction honest:
+
+  1. The opencode.json we emit is real, parseable, and Bedrock-ONLY.
+  2. THE load-bearing control: the two validating agents (reviewer + gate) are read-only
+     by `permission: <cap>: deny` — including `task`, without which a "read-only"
+     reviewer can spawn an unrestricted implementer and launder writes. The implementer
+     carries NO deny at all. Mutating the config to weaken that control must FAIL the
+     emit, not emit a fail-open harness.
+  3. The skill BODIES are shared with the Claude Code target byte-for-byte, except at the
+     {{#TARGET_*}} conditionals and the host-noun scalars.
+  4. The Claude Code target still renders what it rendered before the shared-template
+     edits (regression guard).
+
+Run:  uv run --with pyyaml python tests/test_opencode_emit.py
+  or: uv run --with pytest --with pyyaml pytest tests/test_opencode_emit.py -q
+"""
+import copy
+import json
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "lib"))
+import emit  # noqa: E402
+from render import LEAK_RE  # noqa: E402  (the same gate emit runs)
+
+VERBS = ["intro", "setup", "prime", "inception", "refine", "execute", "wiki", "handoff"]
+
+CFG = {
+    "org": {"name": "Testco", "slug": "testco"},
+    "plugin": {
+        "name": "testco-harness", "version": "0.1.0", "description": "d",
+        "author": {"name": "Testco Platform Engineering", "url": "https://github.com/testco"},
+        "homepage": "https://github.com/testco/testco-harness", "license": "UNLICENSED",
+    },
+    "org_wiki": {
+        "name": "testco-wiki", "remote": "git@github.com:testco/testco-wiki.git",
+        "local_path_env": "TESTCO_WIKI", "default_local_path": "~/work/testco-wiki",
+        "prime_reads": ["operating-model.md", "CLAUDE.md"],
+    },
+    "tracker": {"type": "jira-acli", "config": {
+        "project_key": "TST", "base_url": "https://testco.atlassian.net",
+    }},
+    "model_policy": {"banned": ["haiku"], "default": "sonnet", "rule": "Set model explicitly."},
+    "agents": [
+        {"name": "implementer", "model": "sonnet"},
+        {"name": "reviewer", "model": "sonnet"},
+        {"name": "gate", "model": "sonnet"},
+    ],
+    "opencode": {
+        "provider": {
+            "id": "amazon-bedrock", "profile": "testco-ai", "region": "us-east-1",
+            "models": ["us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                       "us.openai.gpt-5-2025-08-07"],
+        },
+        "model": {"provider": "amazon-bedrock",
+                  "model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0"},
+        "primary_agent": "build",
+        "disabled_providers": ["opencode"],
+        "subagents": {
+            "implementer": {"agent": "implementer", "persona": "Ships small honest changes."},
+            "reviewer": {"agent": "reviewer", "toolFilter": {"allow": ["read", "grep", "glob"]},
+                         "persona": "Judges the diff."},
+            "clearance": {"agent": "gate", "toolFilter": {"allow": ["read", "grep", "glob"]},
+                          "persona": "Verdict plus deficiencies."},
+        },
+        "skills": list(VERBS),
+    },
+}
+
+
+def cfg_with(mutate=None):
+    c = copy.deepcopy(CFG)
+    if mutate:
+        mutate(c)
+    return c
+
+
+def emit_target(target, cfg=None):
+    out = Path(tempfile.mkdtemp(prefix=f"emit-{target}-test-")) / "out"
+    emit.TARGETS[target](cfg or CFG, out)
+    return out
+
+
+# --- opencode.json ---------------------------------------------------------------
+
+def test_opencode_json_is_bedrock_only():
+    out = emit_target("opencode")
+    conf = json.loads((out / "opencode.json").read_text())
+    assert conf["$schema"] == "https://opencode.ai/config.json", conf.get("$schema")
+    # the ALLOWLIST is the load-bearing only-Bedrock control (a deny-list does not cover
+    # a provider auto-detected from an ambient ANTHROPIC_API_KEY / OPENAI_API_KEY)
+    assert conf["enabled_providers"] == ["amazon-bedrock"], conf.get("enabled_providers")
+    assert "opencode" in conf["disabled_providers"], conf["disabled_providers"]
+    assert conf["model"].startswith("amazon-bedrock/"), conf["model"]
+    assert conf["small_model"].startswith("amazon-bedrock/"), conf["small_model"]
+    opts = conf["provider"]["amazon-bedrock"]["options"]
+    assert opts == {"region": "us-east-1", "profile": "testco-ai"}, opts
+    models = conf["provider"]["amazon-bedrock"]["models"]
+    assert set(models) == set(CFG["opencode"]["provider"]["models"]), sorted(models)
+    # singular keys only; the plural forms are a hard error in opencode
+    for bad in ("agents", "commands", "permissions", "plugins"):
+        assert bad not in conf, f"emitted rejected plural top-level key {bad!r}"
+
+
+# --- THE read-only control -------------------------------------------------------
+
+def test_validating_agents_are_read_only():
+    out = emit_target("opencode")
+    for f in ("reviewer.md", "gate.md"):
+        txt = (out / "agent" / f).read_text()
+        for cap in ("edit", "bash", "task", "webfetch", "websearch"):
+            assert f"{cap}: deny" in txt, f"agent/{f} does not deny {cap}"
+        assert "tools:" not in txt, f"agent/{f} uses the deprecated tools: map"
+
+
+def test_implementer_denies_nothing():
+    txt = (emit_target("opencode") / "agent" / "implementer.md").read_text()
+    assert "deny" not in txt, "implementer must keep full tools (no permission denies)"
+    assert "mode: subagent" in txt, txt.splitlines()[:6]
+
+
+def test_derived_deny_comes_from_the_allow_list_not_a_hardcoded_set():
+    """The config must DRIVE the artifact: a reviewer allowed `webfetch` keeps webfetch,
+    and still loses edit/bash/task. If the deny block were hardcoded this fails."""
+    def m(c):
+        c["opencode"]["subagents"]["reviewer"]["toolFilter"]["allow"] = [
+            "read", "grep", "glob", "webfetch"]
+    out = emit_target("opencode", cfg_with(m))
+    txt = (out / "agent" / "reviewer.md").read_text()
+    assert "webfetch: deny" not in txt, \
+        "reviewer denies webfetch even though its allow-list grants it — the deny " \
+        "block is hardcoded, not derived from toolFilter.allow"
+    for cap in ("edit", "bash", "task", "websearch"):
+        assert f"{cap}: deny" in txt, f"reviewer no longer denies {cap}"
+    # and the clearance agent, whose allow-list did NOT change, still denies webfetch
+    gate = (out / "agent" / "gate.md").read_text()
+    assert "webfetch: deny" in gate, "per-agent deny sets collapsed into one shared set"
+
+
+def test_dispatch_name_equals_the_agent_file_that_carries_the_deny_block():
+    """THE blocker regression. Under a `verbs: {gate: review}` rename plus a non-default
+    subagents.clearance.agent, the token the execute skill dispatches must name an agent
+    FILE THAT EXISTS and that file must carry the read-only deny block. If the filename
+    came from verbs['gate'] instead, the dispatch would miss and opencode would fall
+    back to the full-permission primary agent — the gate would run with edit/bash/task.
+    File presence alone is not enough: grep the skill body for the dispatched token."""
+    def m(c):
+        c["verbs"] = {"gate": "review"}
+        c["opencode"]["subagents"]["clearance"]["agent"] = "critic"
+        c["opencode"]["subagents"]["reviewer"]["agent"] = "judge"
+    out = emit_target("opencode", cfg_with(m))
+    body = (out / "skill" / "execute" / "SKILL.md").read_text()
+
+    for role, token in (("clearance", "critic"), ("reviewer", "judge")):
+        assert f"`{token}`" in body, \
+            f"execute skill never dispatches the {role} agent name {token!r}"
+        f = out / "agent" / f"{token}.md"
+        assert f.is_file(), (
+            f"{role} dispatch token {token!r} resolves to NO agent file "
+            f"(present: {sorted(p.name for p in (out / 'agent').iterdir())}) — "
+            f"opencode would fall back to the full-permission primary agent")
+        txt = f.read_text()
+        for cap in ("edit", "bash", "task"):
+            assert f"{cap}: deny" in txt, \
+                f"agent/{token}.md (the {role} the skill dispatches) does not deny {cap}"
+
+    # the verb rename must NOT have produced a verb-named agent file
+    assert not (out / "agent" / "review.md").exists(), \
+        "agent file named from verbs['gate'] — filenames must come from subagents.*.agent"
+    assert not (out / "agent" / "gate.md").exists()
+    # the verb rename DOES still apply to the verb-named surfaces
+    assert (out / "command" / "execute.md").is_file()
+
+
+# --- the REVERSE direction: every dispatch token in every skill body resolves ------
+# The forward test above asks "does the CONFIGURED name appear somewhere?". That cannot
+# see the residual hole: a shared skill that names a role by some OTHER token (the verb,
+# or a hardcoded 'implementer') still dispatches, the configured name still appears
+# elsewhere, and the forward assertion passes — while the dispatch itself resolves to no
+# agent file and opencode silently falls back to the FULL-PERMISSION primary agent. So
+# scan the emitted bodies and demand the reverse: EVERY name used as a dispatch target
+# is an agent file that exists, and no stale token is used as one anywhere.
+
+# A line is dispatch CONTEXT if it instructs/relates a role invocation.
+DISPATCH_CONTEXT_RE = re.compile(r"dispatch|agentType|\bagents?\b|task tool|`task`", re.I)
+# Tokens that must never survive as a dispatch target under a full rename: the template
+# defaults (implementer/reviewer/gate) and the gate VERB (review) — on opencode the agent
+# file is named from subagents.<role>.agent, never from verbs['gate'].
+STALE_DISPATCH_TOKENS = ["implementer", "reviewer", "review", "gate"]
+RENAMED = {"implementer": "builder", "reviewer": "judge", "clearance": "critic"}
+
+
+def _emphasized(token: str, line: str):
+    """A role NAME is written as code or bold in these bodies (`x` / **x** / **`x`**);
+    that emphasis is what distinguishes a dispatch token from prose about the role."""
+    return re.search(r"(?:`|\*\*)%s(?:`|\*\*)" % re.escape(token), line)
+
+
+def _dispatch_hits(out: Path, tokens):
+    """{token: [(relpath, lineno, line)]} for every emphasized token on a dispatch line."""
+    hits = {t: [] for t in tokens}
+    bodies = sorted(out.glob("skill/*/SKILL.md")) + sorted(out.glob("command/*.md"))
+    assert bodies, "no skill/command bodies emitted to scan"
+    for f in bodies:
+        for i, line in enumerate(f.read_text().splitlines(), 1):
+            if not DISPATCH_CONTEXT_RE.search(line):
+                continue
+            for t in tokens:
+                if _emphasized(t, line):
+                    hits[t].append((str(f.relative_to(out)), i, line.strip()))
+    return hits
+
+
+def test_every_dispatched_role_token_resolves_to_an_agent_file_under_a_full_rename():
+    """REVERSE-direction blocker test. Rename ALL THREE roles away from the template
+    defaults AND rename the gate verb, then read the emitted bodies as opencode would:
+
+      (a) every renamed name used as a dispatch target has an agent/<name>.md,
+      (b) judge + critic (the validating roles) carry edit/bash/task deny; builder none,
+      (c) NO stale token (implementer/reviewer/review/gate) is a dispatch target anywhere.
+
+    (c) is the one the pre-fix templates fail: the clearance role was dispatched by VERB
+    ({{VERB_GATE}} → 'review') in execute/refine/intro, which names no agent file here.
+    """
+    def m(c):
+        c["verbs"] = {"gate": "review"}
+        for role, name in RENAMED.items():
+            c["opencode"]["subagents"][role]["agent"] = name
+    out = emit_target("opencode", cfg_with(m))
+    agents = sorted(p.name for p in (out / "agent").iterdir())
+    assert agents == ["builder.md", "critic.md", "judge.md"], agents
+
+    hits = _dispatch_hits(out, list(RENAMED.values()) + STALE_DISPATCH_TOKENS)
+
+    # (c) no stale token may be dispatched — it would resolve to nothing (fail-OPEN).
+    stale = {t: h for t in STALE_DISPATCH_TOKENS if (h := hits[t])}
+    assert not stale, (
+        "dispatch prose names a role by a token that is NOT an emitted agent file "
+        "(opencode falls back to the full-permission primary agent): "
+        + "; ".join(f"{t!r} at " + ", ".join(f"{p}:{i}" for p, i, _ in h)
+                    for t, h in stale.items()))
+
+    # (a) every role IS dispatched by its configured name, and that name resolves.
+    for role, name in RENAMED.items():
+        assert hits[name], (
+            f"no dispatch site names the {role} agent {name!r} — the skills would "
+            f"dispatch it by some other (unresolvable) token, or not at all")
+        assert (out / "agent" / f"{name}.md").is_file(), (
+            f"{role} dispatch token {name!r} resolves to no agent file (present: {agents})")
+
+    # (b) the dispatched validating agents are the read-only ones; the builder is not.
+    for name in ("judge", "critic"):
+        txt = (out / "agent" / f"{name}.md").read_text()
+        for cap in ("edit", "bash", "task"):
+            assert f"{cap}: deny" in txt, f"agent/{name}.md (dispatched) does not deny {cap}"
+    assert "deny" not in (out / "agent" / "builder.md").read_text(), \
+        "agent/builder.md (the implementer) must keep full tools"
+
+
+def test_role_dispatch_scalars_track_the_host_that_emits_the_files():
+    """The scalars themselves: on claude-code they must name the files CC emits (the gate
+    agent is VERB-renamed there); on opencode, subagents.<role>.agent. Same config."""
+    def m(c):
+        c["verbs"] = {"gate": "review"}
+        for role, name in RENAMED.items():
+            c["opencode"]["subagents"][role]["agent"] = name
+    cfg = cfg_with(m)
+    cc = emit.build_bindings(cfg)["scalars"]
+    assert (cc["IMPLEMENTER_AGENT"], cc["REVIEWER_AGENT"], cc["CLEARANCE_AGENT"]) \
+        == ("implementer", "reviewer", "review"), cc["CLEARANCE_AGENT"]
+    oc = emit.build_bindings_opencode(cfg)["scalars"]
+    assert (oc["IMPLEMENTER_AGENT"], oc["REVIEWER_AGENT"], oc["CLEARANCE_AGENT"]) \
+        == ("builder", "judge", "critic"), oc
+
+    # and on CC those three scalars name files the CC target actually emits
+    out = emit_target("claude-code", cfg)
+    for name in (cc["IMPLEMENTER_AGENT"], cc["REVIEWER_AGENT"], cc["CLEARANCE_AGENT"]):
+        assert (out / "agents" / f"{name}.md").is_file(), \
+            f"CC dispatch scalar {name!r} names no emitted agents/{name}.md"
+
+
+def test_mutation_clearance_agent_name_not_in_agent_dir_fails_closed():
+    """Directly mutate the wiring: if the emitted filenames stopped following the
+    dispatch scalars, emit must fail rather than ship an unresolvable dispatch."""
+    real = emit.rename_agent_files
+    try:
+        emit.rename_agent_files = lambda *a, **k: 0   # simulate "filenames not renamed"
+        def m(c):
+            c["opencode"]["subagents"]["clearance"]["agent"] = "critic"
+        try:
+            emit_target("opencode", cfg_with(m))
+        except SystemExit:
+            return
+        raise AssertionError("emitted with a dispatch name that has no agent file")
+    finally:
+        emit.rename_agent_files = real
+
+
+def test_mutation_duplicate_agent_names_fail_closed():
+    def m(c):
+        c["opencode"]["subagents"]["clearance"]["agent"] = "reviewer"
+    try:
+        emit_target("opencode", cfg_with(m))
+    except SystemExit:
+        return
+    raise AssertionError("two roles sharing one agent name emitted instead of failing")
+
+
+def test_mutation_empty_reviewer_allow_fails_closed():
+    def m(c):
+        c["opencode"]["subagents"]["reviewer"]["toolFilter"]["allow"] = []
+    try:
+        emit_target("opencode", cfg_with(m))
+    except SystemExit:
+        return
+    raise AssertionError("empty reviewer toolFilter.allow emitted instead of failing")
+
+
+def test_mutation_write_capability_in_allow_fails_closed():
+    for role, cap in (("reviewer", "edit"), ("reviewer", "bash"),
+                      ("clearance", "task"), ("clearance", "write")):
+        def m(c, role=role, cap=cap):
+            c["opencode"]["subagents"][role]["toolFilter"]["allow"] = ["read", cap]
+        try:
+            emit_target("opencode", cfg_with(m))
+        except SystemExit:
+            continue
+        raise AssertionError(f"{role} allow-list containing {cap!r} emitted instead of failing")
+
+
+def test_mutation_implementer_toolfilter_fails_closed():
+    def m(c):
+        c["opencode"]["subagents"]["implementer"]["toolFilter"] = {"allow": ["read"]}
+    try:
+        emit_target("opencode", cfg_with(m))
+    except SystemExit:
+        return
+    raise AssertionError("implementer toolFilter accepted; it must have full tools")
+
+
+def test_mutation_credential_in_provider_fails_closed():
+    def m(c):
+        c["opencode"]["provider"]["profile"] = "AKIAIOSFODNN7EXAMPLE"
+    try:
+        emit_target("opencode", cfg_with(m))
+    except SystemExit:
+        return
+    raise AssertionError("credential-looking provider value emitted instead of failing")
+
+
+def test_enabled_providers_tracks_the_configured_provider_id():
+    def m(c):
+        c["opencode"]["provider"]["id"] = "bedrock-alt"
+        c["opencode"]["model"]["provider"] = "bedrock-alt"
+    conf = json.loads((emit_target("opencode", cfg_with(m)) / "opencode.json").read_text())
+    assert conf["enabled_providers"] == ["bedrock-alt"], conf["enabled_providers"]
+
+
+def test_mutation_enabled_providers_dropped_from_template_fails_closed():
+    """Delete the allowlist from the emitted config and emit must refuse — otherwise the
+    only-Bedrock claim is theater that no test would notice."""
+    tpl = ROOT / "templates/opencode/opencode.json.template"
+    original = tpl.read_text()
+    stripped = "\n".join(l for l in original.splitlines()
+                         if "enabled_providers" not in l) + "\n"
+    assert stripped != original, "template no longer carries enabled_providers"
+    try:
+        tpl.write_text(stripped)
+        try:
+            emit_target("opencode")
+        except SystemExit:
+            return
+        raise AssertionError("emitted a config with no enabled_providers allowlist")
+    finally:
+        tpl.write_text(original)
+
+
+def test_mutation_zen_provider_left_enabled_fails_closed():
+    def m(c):
+        c["opencode"]["disabled_providers"] = []
+    try:
+        emit_target("opencode", cfg_with(m))
+    except SystemExit:
+        return
+    raise AssertionError("emitted a config that does not hide the built-in provider")
+
+
+# --- shared skill bodies ---------------------------------------------------------
+
+def _normalize(text: str) -> str:
+    """Strip the two places a shared skill is ALLOWED to differ per target:
+    the host-noun scalars, and the target-conditional dispatch section (execute step 5).
+    Everything else must match byte-for-byte."""
+    for host in ("a Claude Code plugin", "an opencode configuration"):
+        text = text.replace(host, "<HOST>")
+    for dispatch in ("Workflow stages", "the task tool"):
+        text = text.replace(dispatch, "<DISPATCH>")
+    # execute's step 5 is the per-target dispatch section, bounded by the next shared line
+    return re.sub(r"^### 5\..*?(?=\*\*Context economy)", "", text, flags=re.S | re.M)
+
+
+def test_shared_skill_bodies_are_identical_across_targets():
+    oc, cc = emit_target("opencode"), emit_target("claude-code")
+    for verb in VERBS:
+        o = oc / "skill" / verb / "SKILL.md"
+        c = cc / "skills" / verb / "SKILL.md"
+        assert o.is_file(), f"missing emitted skill/{verb}/SKILL.md"
+        assert c.is_file(), f"missing emitted skills/{verb}/SKILL.md"
+        no, nc = _normalize(o.read_text()), _normalize(c.read_text())
+        assert no == nc, f"shared body for {verb} diverged between targets"
+
+
+def test_execute_dispatch_is_target_specific():
+    oc = (emit_target("opencode") / "skill" / "execute" / "SKILL.md").read_text()
+    cc = (emit_target("claude-code") / "skills" / "execute" / "SKILL.md").read_text()
+
+    assert "`task` tool" in oc, "opencode execute does not dispatch via the task tool"
+    assert "branch-per-task" in oc.lower() or "own branch" in oc, \
+        "opencode execute does not state branch-per-task isolation"
+    assert "no worktree hook" in oc, "opencode execute does not say worktrees are absent"
+    assert "isolation: 'worktree'" not in oc, \
+        "opencode execute still promises worktree isolation"
+    assert "Workflow" not in oc, "CC Workflow dispatch leaked into the opencode execute"
+
+    assert "Workflow" in cc, "claude-code execute lost its Workflow dispatch"
+    assert "isolation: 'worktree'" in cc, "claude-code execute lost the worktree guidance"
+    assert "`task` tool" not in cc, "opencode task-tool text leaked into the CC execute"
+
+
+def test_intro_names_its_host():
+    oc = (emit_target("opencode") / "skill" / "intro" / "SKILL.md").read_text()
+    cc = (emit_target("claude-code") / "skills" / "intro" / "SKILL.md").read_text()
+    assert "an opencode configuration" in oc, "opencode intro does not name its host"
+    assert "Claude Code plugin" not in oc, "CC host noun leaked into the opencode intro"
+    assert "Claude Code plugin" in cc, "claude-code intro lost its host noun"
+
+
+# --- hygiene ---------------------------------------------------------------------
+
+def test_no_unresolved_placeholders_and_leak_clean():
+    out = emit_target("opencode")
+    files = [p for p in out.rglob("*") if p.is_file()]
+    assert files, "opencode target emitted nothing"
+    for p in files:
+        txt = p.read_text()
+        assert "{{" not in txt, f"unresolved placeholder in {p.relative_to(out)}"
+        hit = LEAK_RE.search(txt)
+        assert not hit, f"identity leak ({hit.group(0)!r}) in {p.relative_to(out)}"
+
+
+def test_exactly_one_target_true_per_target():
+    for target, builder in (("claude-code", emit.build_bindings),
+                            ("opencode", emit.build_bindings_opencode)):
+        conds = builder(CFG)["conditionals"]
+        assert set(conds) == {"TARGET_CC", "TARGET_OPENCODE"}, conds
+        assert sum(1 for v in conds.values() if v) == 1, f"{target}: {conds}"
+    assert emit.build_bindings(CFG)["conditionals"]["TARGET_CC"] is True
+    assert emit.build_bindings_opencode(CFG)["conditionals"]["TARGET_OPENCODE"] is True
+
+
+def test_opencode_layout():
+    out = emit_target("opencode")
+    for rel in ["opencode.json", "AGENTS.md", "README.md", "plugin/reminders.js",
+                "agent/implementer.md", "agent/reviewer.md", "agent/gate.md"]:
+        assert (out / rel).is_file(), f"missing {rel}"
+    for verb in VERBS:
+        assert (out / "command" / f"{verb}.md").is_file(), f"missing command/{verb}.md"
+    # a command runs as the primary agent; execute must NOT be forced into a subagent
+    ex = (out / "command" / "execute.md").read_text()
+    assert "agent: build" in ex, ex.splitlines()[:6]
+    assert "subtask" not in ex, "execute command forces a subtask; the orchestrator is long-lived"
+    # gate is an agent, never a verb/skill on this host
+    assert not (out / "skill" / "gate").exists(), "gate emitted as a skill"
+
+
+def test_verb_renames_apply_to_commands_and_skills_but_not_agents():
+    def m(c):
+        c["verbs"] = {"execute": "engage", "gate": "clearance"}
+    out = emit_target("opencode", cfg_with(m))
+    assert (out / "command" / "engage.md").is_file(), "command not renamed to the org's verb"
+    assert not (out / "command" / "execute.md").exists()
+    assert (out / "skill" / "engage" / "SKILL.md").is_file(), "skill dir not renamed"
+    # agent/ is NOT verb-named: the file name is the dispatch name (subagents.*.agent),
+    # which here is still "gate". Verb-naming it would break the `task` lookup.
+    assert (out / "agent" / "gate.md").is_file(), "agent file must follow subagents.*.agent"
+    assert not (out / "agent" / "clearance.md").exists(), \
+        "gate agent was verb-renamed away from its dispatch name"
+
+
+def test_agent_filenames_follow_the_configured_agent_names():
+    def m(c):
+        c["opencode"]["subagents"]["implementer"]["agent"] = "builder"
+        c["opencode"]["subagents"]["reviewer"]["agent"] = "judge"
+        c["opencode"]["subagents"]["clearance"]["agent"] = "critic"
+    out = emit_target("opencode", cfg_with(m))
+    got = sorted(p.name for p in (out / "agent").iterdir())
+    assert got == ["builder.md", "critic.md", "judge.md"], got
+
+
+# --- claude-code regression ------------------------------------------------------
+
+def test_claude_code_target_still_renders():
+    out = emit_target("claude-code")
+    for rel in ["README.md", ".claude-plugin/plugin.json", "agents/implementer.md",
+                "agents/reviewer.md", "agents/gate.md", "skills/execute/SKILL.md"]:
+        assert (out / rel).is_file(), f"CC regression: missing {rel}"
+    ex = (out / "skills" / "execute" / "SKILL.md").read_text()
+    assert "### 5. Dispatch agents as a Workflow" in ex, "CC lost its Workflow dispatch section"
+    assert "pipeline(tasks," in ex, "CC lost the workflow pipeline example"
+    intro = (out / "skills" / "intro" / "SKILL.md").read_text()
+    assert "agent harness** — a Claude Code plugin that helps" in intro, "CC host noun changed"
+    assert "instantiated by Workflow stages**" in intro, "CC dispatch noun changed"
+    assert not (out / "command").exists(), "CC target emitted an opencode command dir"
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"PASS {fn.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {fn.__name__}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"ERROR {fn.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
Third emit target — `forge emit --target opencode` renders Hyperdrive as an **opencode** configuration, independent of the DSH target (branches from `main`).

## What it emits
- **8 verbs → `command/<verb>.md`** wrappers over the shared `skill/<verb>/SKILL.md` bodies (folded in byte-identical, like the DSH target).
- **3 subagents → `agent/{implementer,reviewer,clearance}.md`**. Reviewer + clearance are read-only via opencode `permission: {edit/bash/task/webfetch/websearch: deny}` — genuinely enforced (opencode removes the tool from the model's set *and* refuses at exec). `task: deny` prevents laundering writes through a spawned agent.
- **Bedrock-only**: `enabled_providers: ["amazon-bedrock"]` (allowlist — robust even when `ANTHROPIC_API_KEY`/`OPENAI_API_KEY` are in the env) + `disabled_providers: ["opencode"]`. Converse serves Claude *and* OpenAI ids through one provider (no per-route wire shape).
- `opencode.json` + thin `AGENTS.md` (wiki pointer) + `README.md` + inert `plugin/reminders.js` stub.

## Design notes
- Introduces the `--target` abstraction (`TARGETS` map; `emit_claude_code` extracted). **CC output is byte-identical to HEAD**, guarded by a `diff -r` test.
- The read-only deny set is **derived per-agent from the config's `toolFilter.allow`** — the config is load-bearing, not theater.
- **Agent filenames and every dispatch-prose token resolve to the same name per target.** Review caught (and this closes) a verb-vs-agent fail-open: a renamed `gate` verb would otherwise dispatch a name with no agent file → opencode falls back to the full-permission primary agent. Covered by a reverse-direction dispatch-contract test under a full 3-role rename.
- Fixes a latent CC/DSH host-language leak (`intro`/`execute` hardcoded "Claude Code plugin"/"Workflow stages" → per-target host-noun scalars).

## Tests / verification
- 25 opencode tests (incl. the reverse-direction dispatch-contract test + mutation tests: empty/writable allow, missing agent file, dropped `enabled_providers`, duplicate agent names → all fail closed). Full suite 39/39.
- **Live-verified**: emitted from the Proscia config, booted opencode against it → only `amazon-bedrock` in `/models`, completed on `us.anthropic.claude-opus-4-8` via the `proscia-ai` profile.

## Out of scope (pre-existing / separate)
- `adapters/tracker/jira-mcp.md` lacks `TRACKER_COMMENT_LIST_SNIPPET`, so the shipped `jira-mcp` example can't emit (unrelated to this change).
- `plugin/reminders.js` ships inert — opencode session-event names unverified; follow-up.