### PR TITLE
feat(emit): opencode target emits a provider whitelist (curate /models)

### DIFF
--- a/lib/emit.py
+++ b/lib/emit.py
@@ -487,6 +487,15 @@ def emit_opencode(cfg: dict, out: Path):
             f"[{sc['OC_BEDROCK_PROVIDER_ID']!r}] — the allowlist is the only-Bedrock "
             f"control that survives an ambient ANTHROPIC_API_KEY/OPENAI_API_KEY "
             f"(got {conf.get('enabled_providers')!r})")
+    # `enabled_providers` scopes PROVIDERS; the per-provider `whitelist` scopes MODELS —
+    # without it opencode merges the whole models.dev Bedrock catalog into the picker.
+    # It must list exactly the declared model ids so /models shows only the org's set.
+    prov_conf = (conf.get("provider") or {}).get(sc["OC_BEDROCK_PROVIDER_ID"], {})
+    declared_ids = list((prov_conf.get("models") or {}).keys())
+    require(declared_ids and prov_conf.get("whitelist") == declared_ids,
+            f"opencode.json provider.{sc['OC_BEDROCK_PROVIDER_ID']}.whitelist must equal the "
+            f"declared model ids {declared_ids!r} — the whitelist curates /models to the org's "
+            f"set and hides the full Bedrock catalog (got {prov_conf.get('whitelist')!r})")
     return rendered, renames
 
 

--- a/templates/opencode/opencode.json.template
+++ b/templates/opencode/opencode.json.template
@@ -16,6 +16,11 @@
         "region": "{{OC_BEDROCK_REGION}}",
         "profile": "{{OC_BEDROCK_PROFILE}}"
       },
+      "whitelist": [
+{{#OC_MODELS}}
+        "{{id}}"{{comma}}
+{{/OC_MODELS}}
+      ],
       "models": {
 {{#OC_MODELS}}
         "{{id}}": { "name": "{{name}}" }{{comma}}

--- a/tests/test_opencode_emit.py
+++ b/tests/test_opencode_emit.py
@@ -103,6 +103,12 @@ def test_opencode_json_is_bedrock_only():
     assert opts == {"region": "us-east-1", "profile": "testco-ai"}, opts
     models = conf["provider"]["amazon-bedrock"]["models"]
     assert set(models) == set(CFG["opencode"]["provider"]["models"]), sorted(models)
+    # `whitelist` scopes MODELS within the provider — without it opencode shows the whole
+    # models.dev Bedrock catalog. It must equal the declared ids (order-preserving) and
+    # the emitted models-map keys, so /models lists ONLY the org's set.
+    wl = conf["provider"]["amazon-bedrock"]["whitelist"]
+    assert wl == list(CFG["opencode"]["provider"]["models"]), wl
+    assert wl == list(models), (wl, list(models))
     # singular keys only; the plural forms are a hard error in opencode
     for bad in ("agents", "commands", "permissions", "plugins"):
         assert bad not in conf, f"emitted rejected plural top-level key {bad!r}"


### PR DESCRIPTION
`enabled_providers` scopes **providers** (only Bedrock); but within Bedrock opencode merges the full models.dev catalog into `/models` (Grok, Opus 5 regional variants, …). This adds a per-provider **`whitelist`** = the declared model ids, so the picker shows only the org's curated set.

- `templates/opencode/opencode.json.template`: emit `provider.<id>.whitelist` from `OC_MODELS`.
- `lib/emit.py`: emit-time artifact check — `whitelist` must equal the declared/emitted model ids (fail-closed).
- Test extends `test_opencode_json_is_bedrock_only`. Suite 39/39.
- **Live-verified**: emitted from the Proscia config → `opencode /models` shows only the 4 declared models, nothing else.

Follow-up to #10.