### PR TITLE
feat(emit): opencode profile is optional (don't pin an AWS profile)

### DIFF
--- a/.forge.org.example.yaml
+++ b/.forge.org.example.yaml
@@ -139,8 +139,12 @@ opencode:
     id: amazon-bedrock                    # the ONLY provider — emitted as an "enabled_providers"
                                           # ALLOWLIST, which holds even when the machine has an
                                           # ambient ANTHROPIC_API_KEY/OPENAI_API_KEY
-    profile: acme-ai                      # an AWS *profile name* — auth comes from the ambient SSO
-    region: us-east-1                     # chain (`aws sso login --profile <name>`). NEVER a key.
+    # profile: acme-ai                    # OPTIONAL and normally OMITTED — pinning one AWS
+                                          # profile name forces every engineer onto it. Leave it
+                                          # out; the emitted README tells each user to add their
+                                          # own profile to provider.options in opencode.json. If
+                                          # you DO set it, it is a profile *name* only, never a key.
+    region: us-east-1                     # auth = ambient AWS chain (`aws sso login --profile <yours>`)
     models:                               # CRIS ids to declare (models.dev doesn't know them)
       - us.anthropic.claude-sonnet-4-5-20250929-v1:0
       - us.openai.gpt-5-2025-08-07

--- a/lib/emit.py
+++ b/lib/emit.py
@@ -236,9 +236,14 @@ def build_bindings_opencode(cfg: dict) -> dict:
             "opencode: block is required for --target opencode")
 
     prov = oc.get("provider") or {}
-    for key in ("id", "profile", "region"):
+    for key in ("id", "region"):
         require(prov.get(key), f"opencode.provider.{key} is required")
         _no_credential(f"opencode.provider.{key}", prov[key])
+    # profile is OPTIONAL: pinning one name forces every engineer onto it. When absent,
+    # auth falls through the ambient AWS chain (AWS_PROFILE / default profile / SSO /
+    # instance role) — the emitted README explains it.
+    if prov.get("profile"):
+        _no_credential("opencode.provider.profile", prov["profile"])
     for stray in sorted(set(prov) - {"id", "profile", "region", "models"}):
         _no_credential(f"opencode.provider.{stray}", stray)
         _no_credential(f"opencode.provider.{stray}", prov[stray])
@@ -328,7 +333,7 @@ def build_bindings_opencode(cfg: dict) -> dict:
         "OC_DEFAULT_MODEL_REF": default_ref,
         "OC_SMALL_MODEL_REF": small_ref,
         "OC_BEDROCK_PROVIDER_ID": prov.get("id", "amazon-bedrock"),
-        "OC_BEDROCK_PROFILE": prov["profile"],
+        "OC_BEDROCK_PROFILE": prov.get("profile", ""),
         "OC_BEDROCK_REGION": prov["region"],
         "OC_PRIMARY_AGENT": oc.get("primary_agent", "build"),
         "OC_IMPLEMENTER_AGENT": subs["implementer"]["agent"],
@@ -363,7 +368,8 @@ def build_bindings_opencode(cfg: dict) -> dict:
         "OC_REVIEWER_DENY": [{"cap": c} for c in reviewer_deny],
         "OC_CLEARANCE_DENY": [{"cap": c} for c in clearance_deny],
     })
-    b["conditionals"] = {"TARGET_CC": False, "TARGET_OPENCODE": True}
+    b["conditionals"] = {"TARGET_CC": False, "TARGET_OPENCODE": True,
+                         "OC_HAS_PROFILE": bool(prov.get("profile"))}
     return b
 
 

--- a/templates/opencode/README.md.template
+++ b/templates/opencode/README.md.template
@@ -36,12 +36,31 @@ startup — an already-running session will not see them.
 
 ## Authenticate (no API keys anywhere)
 
-The provider is Amazon Bedrock through your **ambient AWS credential chain**. There is no
-key in `opencode.json` — only a profile *name* and a region. Log in before you start:
+The provider is Amazon Bedrock through your AWS credentials — there is **no API key** in
+`opencode.json`, and **no profile is pinned** (every engineer names their AWS profiles
+differently). Add YOUR profile to the provider options in `opencode.json` — this is an
+opencode setting, not an environment variable:
+
+```jsonc
+"provider": {
+  "{{OC_BEDROCK_PROVIDER_ID}}": {
+    "options": {
+      "region": "{{OC_BEDROCK_REGION}}",
+      "profile": "<your-aws-profile>"    // a profile that can invoke Bedrock
+    }
+  }
+}
+```
+
+Then make sure that profile is logged in before you start:
 
 ```
-aws sso login --profile {{OC_BEDROCK_PROFILE}}
+aws sso login --profile <your-aws-profile>
 ```
+{{#OC_HAS_PROFILE}}
+(This deployment shipped with `profile: {{OC_BEDROCK_PROFILE}}` already set — replace it
+with your own profile name above if it differs.)
+{{/OC_HAS_PROFILE}}
 
 Region: `{{OC_BEDROCK_REGION}}`. Default model: `{{OC_DEFAULT_MODEL_REF}}`.
 If a session says it cannot reach the model, your SSO session has almost certainly

--- a/templates/opencode/opencode.json.template
+++ b/templates/opencode/opencode.json.template
@@ -13,8 +13,8 @@
   "provider": {
     "{{OC_BEDROCK_PROVIDER_ID}}": {
       "options": {
-        "region": "{{OC_BEDROCK_REGION}}",
-        "profile": "{{OC_BEDROCK_PROFILE}}"
+        "region": "{{OC_BEDROCK_REGION}}"{{#OC_HAS_PROFILE}},
+        "profile": "{{OC_BEDROCK_PROFILE}}"{{/OC_HAS_PROFILE}}
       },
       "models": {
 {{#OC_MODELS}}

--- a/tests/test_opencode_emit.py
+++ b/tests/test_opencode_emit.py
@@ -54,7 +54,7 @@ CFG = {
     ],
     "opencode": {
         "provider": {
-            "id": "amazon-bedrock", "profile": "testco-ai", "region": "us-east-1",
+            "id": "amazon-bedrock", "region": "us-east-1",
             "models": ["us.anthropic.claude-sonnet-4-5-20250929-v1:0",
                        "us.openai.gpt-5-2025-08-07"],
         },
@@ -99,13 +99,23 @@ def test_opencode_json_is_bedrock_only():
     assert "opencode" in conf["disabled_providers"], conf["disabled_providers"]
     assert conf["model"].startswith("amazon-bedrock/"), conf["model"]
     assert conf["small_model"].startswith("amazon-bedrock/"), conf["small_model"]
+    # no profile is pinned by default — each engineer adds their own in opencode settings
     opts = conf["provider"]["amazon-bedrock"]["options"]
-    assert opts == {"region": "us-east-1", "profile": "testco-ai"}, opts
+    assert opts == {"region": "us-east-1"}, opts
     models = conf["provider"]["amazon-bedrock"]["models"]
     assert set(models) == set(CFG["opencode"]["provider"]["models"]), sorted(models)
     # singular keys only; the plural forms are a hard error in opencode
     for bad in ("agents", "commands", "permissions", "plugins"):
         assert bad not in conf, f"emitted rejected plural top-level key {bad!r}"
+
+
+def test_profile_is_optional_pinned_only_when_configured():
+    """Default: no profile in options (pinning one forces every engineer onto that name).
+    When a profile IS configured, it is emitted verbatim."""
+    out = emit_target("opencode", cfg_with(
+        lambda c: c["opencode"]["provider"].__setitem__("profile", "acme-ai")))
+    opts = json.loads((out / "opencode.json").read_text())["provider"]["amazon-bedrock"]["options"]
+    assert opts == {"region": "us-east-1", "profile": "acme-ai"}, opts
 
 
 # --- THE read-only control -------------------------------------------------------
@@ -458,8 +468,9 @@ def test_exactly_one_target_true_per_target():
     for target, builder in (("claude-code", emit.build_bindings),
                             ("opencode", emit.build_bindings_opencode)):
         conds = builder(CFG)["conditionals"]
-        assert set(conds) == {"TARGET_CC", "TARGET_OPENCODE"}, conds
-        assert sum(1 for v in conds.values() if v) == 1, f"{target}: {conds}"
+        targets = {k: v for k, v in conds.items() if k.startswith("TARGET_")}
+        assert set(targets) == {"TARGET_CC", "TARGET_OPENCODE"}, conds
+        assert sum(1 for v in targets.values() if v) == 1, f"{target}: {conds}"
     assert emit.build_bindings(CFG)["conditionals"]["TARGET_CC"] is True
     assert emit.build_bindings_opencode(CFG)["conditionals"]["TARGET_OPENCODE"] is True
 


### PR DESCRIPTION
Pinning one AWS profile name in the emitted `opencode.json` forces every engineer onto it. This makes it optional.

- **Default: no `profile` emitted** — `provider.options` carries only `region`. opencode's Bedrock provider then uses the ambient AWS chain.
- The emitted **README explains how to add your own profile in opencode settings** (`provider.<id>.options.profile` in `opencode.json`), not via an `AWS_PROFILE` env var.
- If a config *does* set `opencode.provider.profile`, it's still emitted (`OC_HAS_PROFILE` conditional) and the README notes it.
- `.forge.org.example.yaml` comments the profile out as OPTIONAL/omitted.
- Tests: default → `options == {region}`; with-profile → `options == {region, profile}`. Suite 40/40.

Follow-up to #10.