### PR TITLE
feat(emit): opencode grants external_directory read (harness reads the wiki)

### DIFF
--- a/templates/opencode/opencode.json.template
+++ b/templates/opencode/opencode.json.template
@@ -10,6 +10,7 @@
   "small_model": "{{OC_SMALL_MODEL_REF}}",
   "default_agent": "{{OC_PRIMARY_AGENT}}",
   "instructions": ["AGENTS.md"],
+  "permission": { "external_directory": "allow" },
   "provider": {
     "{{OC_BEDROCK_PROVIDER_ID}}": {
       "options": {

--- a/tests/test_opencode_emit.py
+++ b/tests/test_opencode_emit.py
@@ -104,6 +104,9 @@ def test_opencode_json_is_bedrock_only():
     assert opts == {"region": "us-east-1"}, opts
     models = conf["provider"]["amazon-bedrock"]["models"]
     assert set(models) == set(CFG["opencode"]["provider"]["models"]), sorted(models)
+    # external-dir reads allowed (the harness reads the wiki, which lives outside cwd);
+    # writes stay gated by `edit`, so the read-only agents still cannot write it
+    assert conf["permission"]["external_directory"] == "allow", conf.get("permission")
     # singular keys only; the plural forms are a hard error in opencode
     for bad in ("agents", "commands", "permissions", "plugins"):
         assert bad not in conf, f"emitted rejected plural top-level key {bad!r}"


### PR DESCRIPTION
The harness reads the org wiki, which commonly lives **outside the working tree**. opencode's `external_directory` permission (default `ask`) blocks every such read. Emit top-level `permission: { external_directory: "allow" }`.

- **Reads only** — writes stay gated by `edit`, so the read-only reviewer/clearance still cannot write anything (incl. the wiki); only the full-tool build agent can read+write it.
- Verified: with this set, a wiki read from an unrelated cwd goes through with no prompt.
- Note: a path-*scoped* external-dir allow was attempted but opencode's glob matcher didn't cooperate and `references` hung; flat allow is the reliable, portable option (and the wiki is usually in-tree anyway, so it only fires in the split-dir case).

Follow-up to #10.